### PR TITLE
add missing requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /usr/src/agentd
 WORKDIR /usr/src/agentd
-RUN pip install -r requirements.txt
+RUN apt-get update && apt-get install -y gcc && pip install -r requirements.txt
 RUN python setup.py install
 
 FROM python:3.7-slim-buster AS build-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ flask-restful==0.3.7
 flask==1.0.2
 kombu==4.2.1
 marshmallow==3.0.0b14
+netifaces==0.10.4
 psycopg2==2.7.7  # from xivo-dao
 python-consul==0.7.1
 pyyaml==3.13  # from xivo-lib-python


### PR DESCRIPTION
Why:

* When using consul, wazo-agentd stops complaining that netifaces is not
present
