### PR TITLE
set pg application_name

### DIFF
--- a/etc/wazo-agentd/config.yml
+++ b/etc/wazo-agentd/config.yml
@@ -16,7 +16,7 @@ debug: false
 logfile: /var/log/wazo-agentd.log
 
 # Database connection informations.
-db_uri: postgresql://asterisk:proformatique@localhost/asterisk
+db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-agentd
 
 amid:
   host: localhost


### PR DESCRIPTION
why: used for traceability
replace: https://github.com/wazo-platform/xivo-dao/pull/23