### PR TITLE
logoff: handle unlogged interface on logoff

### DIFF
--- a/wazo_agentd/service/action/tests/test_logoff.py
+++ b/wazo_agentd/service/action/tests/test_logoff.py
@@ -1,14 +1,14 @@
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
 import unittest
 
-from mock import Mock, ANY
-
-from xivo_bus.resources.cti.event import AgentStatusUpdateEvent
+from mock import ANY, Mock
 
 from wazo_agentd.service.action.logoff import LogoffAction
+from wazo_amid_client.exceptions import AmidProtocolError
+from xivo_bus.resources.cti.event import AgentStatusUpdateEvent
 
 
 class TestLogoffAction(unittest.TestCase):
@@ -41,6 +41,45 @@ class TestLogoffAction(unittest.TestCase):
             Mock(uuid='42'),
             Mock(uuid='43'),
         ]
+
+        self.logoff_action.logoff_agent(agent_status)
+
+        self.amid_client.action.assert_called_once_with(
+            'QueueRemove', {'Queue': queue.name, 'Interface': agent_status.interface}
+        )
+        self.queue_log_manager.on_agent_logged_off.assert_called_once_with(
+            agent_number, agent_status.extension, agent_status.context, ANY
+        )
+        self.agent_status_dao.remove_agent_from_all_queues.assert_called_once_with(
+            agent_id
+        )
+        self.agent_status_dao.log_off_agent.assert_called_once_with(agent_id)
+        self.bus_publisher.publish.assert_called_once_with(
+            AgentStatusUpdateEvent(10, AgentStatusUpdateEvent.STATUS_LOGGED_OUT),
+            headers={'user_uuid:42': True, 'user_uuid:43': True, 'agent_id:10': True},
+        )
+
+    def test_logoff_agent_already_off_on_asterisk(self):
+        agent_id = 10
+        agent_number = '10'
+        queue_name = 'q1'
+        queue = Mock()
+        queue.name = queue_name
+        agent_status = Mock()
+        agent_status.agent_id = agent_id
+        agent_status.agent_number = agent_number
+        agent_status.login_at = datetime.datetime.utcnow()
+        agent_status.queues = [queue]
+        self.user_dao.find_all_by_agent_id.return_value = [
+            Mock(uuid='42'),
+            Mock(uuid='43'),
+        ]
+
+        response = Mock()
+        response.json.return_value = [
+            {'Message': 'Unable to remove interface: Not there'}
+        ]
+        self.amid_client.action.side_effect = AmidProtocolError(response)
 
         self.logoff_action.logoff_agent(agent_status)
 


### PR DESCRIPTION
Whenever Asterisk and wazo-agentd get out of sync and an agent is logged in on
agentd but logged out in Asterisk. Then it is impossible to log out that agent.
doing *32<agent number> would get a 500 from agentd and fail the AGI call with
no sound prompt to the user.

This change will keep updating the db if the agent was not logged into the
Asterisk queue. Allowing the user to log back in without having to mess with the
DB.