### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,4 +1,3 @@
-docker-compose
 kombu
 openapi-spec-validator
 psycopg2-binary  # from sqlalchemy


### PR DESCRIPTION
why: to have the latest docker-compose