### PR TITLE
WAZO-2731-pause-me-no-body

### DIFF
--- a/wazo_agentd/swagger/api.yml
+++ b/wazo_agentd/swagger/api.yml
@@ -311,6 +311,12 @@ paths:
       - user
       parameters:
       - $ref: '#/parameters/tenantuuid'
+      - name: body
+        in: body
+        description: The reason when pause the agent
+        required: false
+        schema:
+          $ref: '#/definitions/AgentPauseReason'
       responses:
         '204':
           description: The operation was performed succesfully

--- a/wazo_agentd/swagger/api.yml
+++ b/wazo_agentd/swagger/api.yml
@@ -286,7 +286,7 @@ paths:
       - $ref: '#/parameters/AgentNumber'
       - name: body
         in: body
-        description: The reason when pause the agent
+        description: The reason for pausing the agent
         required: false
         schema:
           $ref: '#/definitions/AgentPauseReason'
@@ -313,7 +313,7 @@ paths:
       - $ref: '#/parameters/tenantuuid'
       - name: body
         in: body
-        description: The reason when pause the agent
+        description: The reason for pausing the agent
         required: false
         schema:
           $ref: '#/definitions/AgentPauseReason'


### PR DESCRIPTION
the missing body resulted in users not being able to set an empty body on the
POST getting a 400 error when using the API console