### PR TITLE
WAZO-2742-logged-off-while-paused

### DIFF
--- a/wazo_agentd/main.py
+++ b/wazo_agentd/main.py
@@ -124,16 +124,18 @@ def _run(config):
         agent_dao,
         bus_publisher,
     )
+    pause_action = PauseAction(amid_client)
+    pause_manager = PauseManager(pause_action, agent_dao)
     logoff_action = LogoffAction(
         amid_client,
         queue_log_manager,
         blf_manager,
+        pause_manager,
         agent_status_dao,
         user_dao,
         agent_dao,
         bus_publisher,
     )
-    pause_action = PauseAction(amid_client)
     remove_from_queue_action = RemoveFromQueueAction(amid_client, agent_status_dao)
     update_penalty_action = UpdatePenaltyAction(amid_client, agent_status_dao)
 
@@ -157,7 +159,6 @@ def _run(config):
     on_queue_agent_paused_manager = OnQueueAgentPausedManager(
         agent_status_dao, user_dao, agent_dao, bus_publisher
     )
-    pause_manager = PauseManager(pause_action, agent_dao)
     relog_manager = RelogManager(
         login_action, logoff_action, agent_dao, agent_status_dao
     )

--- a/wazo_agentd/service/action/logoff.py
+++ b/wazo_agentd/service/action/logoff.py
@@ -17,6 +17,7 @@ class LogoffAction:
         amid_client,
         queue_log_manager,
         blf_manager,
+        pause_manager,
         agent_status_dao,
         user_dao,
         agent_dao,
@@ -25,6 +26,7 @@ class LogoffAction:
         self._amid_client = amid_client
         self._queue_log_manager = queue_log_manager
         self._blf_manager = blf_manager
+        self._pause_manager = pause_manager
         self._agent_status_dao = agent_status_dao
         self._user_dao = user_dao
         self._agent_dao = agent_dao
@@ -33,11 +35,15 @@ class LogoffAction:
     def logoff_agent(self, agent_status):
         # Precondition:
         # * agent is logged
+        self._unpause_agent(agent_status)
         self._update_asterisk(agent_status)
         self._update_blf(agent_status)
         self._update_queue_log(agent_status)
         self._update_agent_status(agent_status)
         self._send_bus_status_update(agent_status)
+
+    def _unpause_agent(self, agent_status):
+        self._pause_manager.unpause_agent(agent_status)
 
     def _update_asterisk(self, agent_status):
         for queue in agent_status.queues:

--- a/wazo_agentd/service/action/tests/test_logoff.py
+++ b/wazo_agentd/service/action/tests/test_logoff.py
@@ -17,6 +17,7 @@ class TestLogoffAction(unittest.TestCase):
         self.amid_client = Mock()
         self.queue_log_manager = Mock()
         self.blf_manager = Mock()
+        self.pause_manager = Mock()
         self.agent_status_dao = Mock()
         self.user_dao = Mock()
         self.agent_dao = Mock()
@@ -25,6 +26,7 @@ class TestLogoffAction(unittest.TestCase):
             self.amid_client,
             self.queue_log_manager,
             self.blf_manager,
+            self.pause_manager,
             self.agent_status_dao,
             self.user_dao,
             self.agent_dao,
@@ -68,6 +70,7 @@ class TestLogoffAction(unittest.TestCase):
                 call(user_id, 'agentstaticlogtoggle', 'NOT_INUSE', agent_number),
             ),
         )
+        self.pause_manager.unpause_agent.assert_called_once_with(agent_status)
         self.queue_log_manager.on_agent_logged_off.assert_called_once_with(
             agent_number, agent_status.extension, agent_status.context, ANY
         )


### PR DESCRIPTION
this avoids having statistics where an agent could be logged over its login period