### PR TITLE
test: use mock from unittest library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pyhamcrest
 pytest

--- a/wazo_agentd/service/action/tests/test_login.py
+++ b/wazo_agentd/service/action/tests/test_login.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import call, Mock, ANY
+from unittest.mock import call, Mock, ANY
 from hamcrest import assert_that, contains_inanyorder
 
 from xivo_bus.resources.cti.event import AgentStatusUpdateEvent

--- a/wazo_agentd/service/action/tests/test_logoff.py
+++ b/wazo_agentd/service/action/tests/test_logoff.py
@@ -4,7 +4,7 @@
 import datetime
 import unittest
 
-from mock import ANY, call, Mock
+from unittest.mock import ANY, call, Mock
 from hamcrest import assert_that, contains_inanyorder
 
 from wazo_agentd.service.action.logoff import LogoffAction

--- a/wazo_agentd/service/action/tests/test_pause.py
+++ b/wazo_agentd/service/action/tests/test_pause.py
@@ -1,8 +1,8 @@
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from wazo_agentd.service.action.pause import PauseAction
 
 

--- a/wazo_agentd/service/handler/tests/test_login.py
+++ b/wazo_agentd/service/handler/tests/test_login.py
@@ -1,8 +1,8 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from wazo_agentd.service.handler.login import LoginHandler
 from wazo_agentd.service.manager.login import LoginManager
 

--- a/wazo_agentd/service/handler/tests/test_logoff.py
+++ b/wazo_agentd/service/handler/tests/test_logoff.py
@@ -1,8 +1,8 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from wazo_agentd.service.handler.logoff import LogoffHandler
 from wazo_agentd.service.manager.logoff import LogoffManager
 

--- a/wazo_agentd/service/handler/tests/test_pause.py
+++ b/wazo_agentd/service/handler/tests/test_pause.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 from wazo_agentd.service.manager.pause import PauseManager
 from wazo_agentd.service.manager.on_queue_agent_paused import OnQueueAgentPausedManager
 from wazo_agentd.service.handler.pause import PauseHandler

--- a/wazo_agentd/service/handler/tests/test_relog.py
+++ b/wazo_agentd/service/handler/tests/test_relog.py
@@ -1,8 +1,8 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from wazo_agentd.service.manager.relog import RelogManager
 from wazo_agentd.service.handler.relog import RelogHandler
 

--- a/wazo_agentd/service/manager/tests/test_add_member.py
+++ b/wazo_agentd/service/manager/tests/test_add_member.py
@@ -1,9 +1,9 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 
 from wazo_agentd.service.manager.add_member import AddMemberManager
 from wazo_agentd.exception import AgentAlreadyInQueueError, QueueDifferentTenantError

--- a/wazo_agentd/service/manager/tests/test_login.py
+++ b/wazo_agentd/service/manager/tests/test_login.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 
 from wazo_agentd.service.manager.login import LoginManager
 from wazo_agentd.exception import ContextDifferentTenantError

--- a/wazo_agentd/service/manager/tests/test_logoff.py
+++ b/wazo_agentd/service/manager/tests/test_logoff.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 
 from wazo_agentd.service.manager.logoff import LogoffManager
 

--- a/wazo_agentd/service/manager/tests/test_on_agent_paused.py
+++ b/wazo_agentd/service/manager/tests/test_on_agent_paused.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import Mock, sentinel as s
+from unittest.mock import Mock, sentinel as s
 
 from ..on_queue_agent_paused import OnQueueAgentPausedManager
 from ..on_queue_agent_paused import PauseAgentEvent, UnpauseAgentEvent

--- a/wazo_agentd/service/manager/tests/test_on_agent_updated.py
+++ b/wazo_agentd/service/manager/tests/test_on_agent_updated.py
@@ -1,8 +1,8 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from wazo_agentd.service.manager.on_agent_updated import (
     OnAgentUpdatedManager,
     QueueDelta,

--- a/wazo_agentd/service/manager/tests/test_relog.py
+++ b/wazo_agentd/service/manager/tests/test_relog.py
@@ -1,8 +1,8 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from wazo_agentd.service.action.login import LoginAction
 from wazo_agentd.service.action.logoff import LogoffAction
 from wazo_agentd.service.manager.relog import RelogManager

--- a/wazo_agentd/service/tests/test_proxy.py
+++ b/wazo_agentd/service/tests/test_proxy.py
@@ -1,9 +1,9 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from mock import Mock, sentinel as s
+from unittest.mock import Mock, sentinel as s
 from wazo_agentd.service.handler.login import LoginHandler
 from wazo_agentd.service.handler.logoff import LogoffHandler
 from wazo_agentd.service.handler.membership import MembershipHandler

--- a/wazo_agentd/tests/test_queuelog.py
+++ b/wazo_agentd/tests/test_queuelog.py
@@ -1,10 +1,10 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
 import unittest
 from functools import wraps
-from mock import ANY, Mock, patch, sentinel
+from unittest.mock import ANY, Mock, patch, sentinel
 from wazo_agentd.queuelog import QueueLogManager
 
 mock_date = datetime.datetime(2011, 11, 12, 13, 14, 15, 1617)


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package