### PR TITLE
disable consul/service_discovery by default

### DIFF
--- a/debian/wazo-agentd.links
+++ b/debian/wazo-agentd.links
@@ -1,2 +1,0 @@
-/var/lib/consul/default_xivo_consul_config.yml /etc/wazo-agentd/conf.d/050-xivo-consul-config.yml
-/var/lib/consul/default_xivo_consul_token.yml /etc/wazo-agentd/conf.d/050-xivo-consul-token.yml

--- a/etc/wazo-agentd/config.yml
+++ b/etc/wazo-agentd/config.yml
@@ -59,12 +59,12 @@ rest_api:
 service_discovery:
   enabled: false
 
-# Example of service discovery settings
+# Example settings to enable service discovery
 #
 # Necessary to use service discovery
 # consul:
 #   scheme: http
-#   host: localhost
+#   host: consul.example.com
 #   port: 8500
 #   token: 'the_one_ring'
 #

--- a/etc/wazo-agentd/config.yml
+++ b/etc/wazo-agentd/config.yml
@@ -38,13 +38,6 @@ bus:
   exchange_name: xivo
   exchange_type: topic
 
-# consul connection settings
-consul:
-  scheme: http
-  host: localhost
-  port: 8500
-  token: 'the_one_ring'
-
 # REST API server
 rest_api:
 
@@ -63,21 +56,35 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-# Service discovery configuration. all time intervals are in seconds
 service_discovery:
-  # The address that will be received by other services using service discovery.
-  # Use "advertise_address: auto" to enable ip address detection based on
-  # advertise_address_interface
-  advertise_address: auto
-  # If advertise_address is "auto" this interface will be used to find the ip
-  # address to advertise. Ignored otherwise
-  advertise_address_interface: eth0
-  advertise_port: 9493
-  # The number of seconds that consul will wait between 2 ttl messages to mark
-  # this service as up
-  ttl_interval: 30
-  # The time interval before the service sends a new ttl message to consul
-  refresh_interval: 27
-  # The time interval to detect that the service is running when starting
-  retry_interval: 2
-  extra_tags: []
+  enabled: false
+
+# Example of service discovery settings
+#
+# Necessary to use service discovery
+# consul:
+#   scheme: http
+#   host: localhost
+#   port: 8500
+#   token: 'the_one_ring'
+#
+# All time intervals are in seconds
+# service_discovery:
+#   # Indicates whether of not to use service discovery.
+#   enabled: true
+#   # The address that will be received by other services using service discovery.
+#   # Use "advertise_address: auto" to enable ip address detection based on
+#   # advertise_address_interface
+#   advertise_address: auto
+#   # If advertise_address is "auto" this interface will be used to find the ip
+#   # address to advertise. Ignored otherwise
+#   advertise_address_interface: eth0
+#   advertise_port: 9493
+#   # The number of seconds that consul will wait between 2 ttl messages to mark
+#   # this service as up
+#   ttl_interval: 30
+#   # The time interval before the service sends a new ttl message to consul
+#   refresh_interval: 27
+#   # The time interval to detect that the service is running when starting
+#   retry_interval: 2
+#   extra_tags: []

--- a/integration_tests/assets/etc/wazo-agentd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-agentd/conf.d/50-default.yml
@@ -10,5 +10,3 @@ auth:
   password: agentd-password
 bus:
   host: rabbitmq
-service_discovery:
-  enabled: false

--- a/wazo_agentd/config.py
+++ b/wazo_agentd/config.py
@@ -36,7 +36,6 @@ _DEFAULT_CONFIG = {
             'exchange_type': 'headers',
         },
     },
-    'consul': {'scheme': 'http', 'host': 'localhost', 'port': 8500},
     'rest_api': {
         'listen': '127.0.0.1',
         'port': _DEFAULT_HTTP_PORT,
@@ -47,15 +46,19 @@ _DEFAULT_CONFIG = {
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
     },
+    'consul': {
+        'scheme': 'http',
+        'port': 8500,
+    },
     'service_discovery': {
-        'enabled': True,
-        'advertise_address': 'localhost',
-        'advertise_port': _DEFAULT_HTTP_PORT,
+        'enabled': False,
+        'advertise_address': 'auto',
         'advertise_address_interface': 'eth0',
-        'refresh_interval': 25,
+        'advertise_port': _DEFAULT_HTTP_PORT,
+        'extra_tags': [],
+        'refresh_interval': 27,
         'retry_interval': 2,
         'ttl_interval': 30,
-        'extra_tags': [],
     },
 }
 


### PR DESCRIPTION
why: consul is not used in default install
- Remove host key from default consul setting to block service start if
  not defined
- Keep common service_discovery and consul key in config.py to avoid
  to redefine everything when using these settings