### PR TITLE
Limit sqlalchemy to version 1 in tests

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -5,7 +5,7 @@ psycopg2-binary  # from sqlalchemy
 pyhamcrest
 pytest
 requests
-sqlalchemy
+sqlalchemy<2
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-agentd-client/archive/master.zip
 https://github.com/wazo-platform/xivo-dao/archive/master.zip


### PR DESCRIPTION
sqlalchemy version 2.0 needs work before the migration

https://docs.sqlalchemy.org/en/14/changelog/migration_20.html