### PR TITLE
tests: pin SQLAlchemy to 1.2.18

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -28,7 +28,6 @@ logger = logging.getLogger(__name__)
 
 
 class BaseIntegrationTest(AssetLaunchingTestCase):
-
     assets_root = os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..', '..', 'assets')
     )

--- a/integration_tests/suite/helpers/database.py
+++ b/integration_tests/suite/helpers/database.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -25,7 +25,6 @@ TENANT_UUID = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1'
 
 
 class DbHelper(object):
-
     TEMPLATE = "xivotemplate"
 
     @classmethod

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -27,7 +27,6 @@ from .helpers import associations, fixtures
 
 
 class TestAgents(BaseIntegrationTest):
-
     asset = 'base'
 
     def test_authentication(self):
@@ -59,7 +58,6 @@ class TestAgents(BaseIntegrationTest):
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()
     def test_login_logoff(self, user_line_extension, agent):
-
         self.agentd.agents.login_agent(
             agent['id'],
             user_line_extension['exten'],
@@ -77,7 +75,6 @@ class TestAgents(BaseIntegrationTest):
     @fixtures.user_line_extension(exten='1001', context='default', name_line='abcdef')
     @fixtures.agent(number='1234')
     def test_agent_status(self, user_line_extension, agent):
-
         self.agentd.agents.login_agent(
             agent['id'],
             user_line_extension['exten'],

--- a/integration_tests/suite/test_agents_by_number.py
+++ b/integration_tests/suite/test_agents_by_number.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, has_entries, has_key, all_of
@@ -9,7 +9,6 @@ from .helpers import fixtures
 
 
 class TestAgentsByNumber(BaseIntegrationTest):
-
     asset = 'base'
 
     @fixtures.user_line_extension(exten='1001', context='default')

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -16,7 +16,6 @@ logger.setLevel(logging.INFO)
 
 
 class TestDocumentation(BaseIntegrationTest):
-
     asset = 'base'
 
     def test_documentation_errors(self):

--- a/integration_tests/suite/test_event_handler.py
+++ b/integration_tests/suite/test_event_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -11,7 +11,6 @@ from .helpers import fixtures
 
 
 class TestEventHandler(BaseIntegrationTest):
-
     asset = 'base'
 
     @fixtures.user_line_extension(exten='1001', context='default')

--- a/integration_tests/suite/test_status.py
+++ b/integration_tests/suite/test_status.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -14,7 +14,6 @@ from .helpers.base import BaseIntegrationTest
 
 
 class TestStatus(BaseIntegrationTest):
-
     asset = 'base'
 
     def test_agentd_status_is_ok(self):

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -5,7 +5,7 @@ psycopg2-binary  # from sqlalchemy
 pyhamcrest
 pytest
 requests
-sqlalchemy
+sqlalchemy==1.2.18  # from xivo-dao
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-agentd-client/archive/master.zip
 https://github.com/wazo-platform/xivo-dao/archive/master.zip

--- a/wazo_agentd/dao.py
+++ b/wazo_agentd/dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections import namedtuple
@@ -48,7 +48,6 @@ class ExtenFeaturesDAOAdapter(_AbstractDAOAdapter):
 
 
 class QueueDAOAdapter(_AbstractDAOAdapter):
-
     _PENALTY = 0
 
     def get_queue(self, queue_id, tenant_uuids=None):

--- a/wazo_agentd/exception.py
+++ b/wazo_agentd/exception.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # The following strings are part of the exposed HTTP API; don't rename them
@@ -17,62 +17,50 @@ QUEUE_DIFFERENT_TENANT = 'agent and queue are not in the same tenant'
 
 
 class AgentServerError(Exception):
-
     error = 'server error'
 
 
 class NoSuchAgentError(AgentServerError):
-
     error = NO_SUCH_AGENT
 
 
 class NoSuchExtensionError(AgentServerError):
-
     error = NO_SUCH_EXTEN
 
 
 class NoSuchLineError(AgentServerError):
-
     error = NO_SUCH_LINE
 
 
 class NoSuchQueueError(AgentServerError):
-
     error = NO_SUCH_QUEUE
 
 
 class AgentNotLoggedError(AgentServerError):
-
     error = NOT_LOGGED
 
 
 class AgentAlreadyLoggedError(AgentServerError):
-
     error = ALREADY_LOGGED
 
 
 class AgentNotInQueueError(AgentServerError):
-
     error = NOT_IN_QUEUE
 
 
 class AgentAlreadyInQueueError(AgentServerError):
-
     error = ALREADY_IN_QUEUE
 
 
 class ExtensionAlreadyInUseError(AgentServerError):
-
     error = ALREADY_IN_USE
 
 
 class ContextDifferentTenantError(AgentServerError):
-
     error = CONTEXT_DIFFERENT_TENANT
 
 
 class QueueDifferentTenantError(AgentServerError):
-
     error = QUEUE_DIFFERENT_TENANT
 
 

--- a/wazo_agentd/http.py
+++ b/wazo_agentd/http.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -104,7 +104,6 @@ def _common_error_handler(fun):
 
 
 class _BaseResource(Resource):
-
     method_decorators = [auth_verifier.verify_token, _common_error_handler]
 
     def parse_params(self):
@@ -311,7 +310,6 @@ class _UnpauseUserAgent(_BaseResource):
 
 
 class HTTPInterface:
-
     VERSION = '1.0'
 
     _resources = [

--- a/wazo_agentd/swagger/resource.py
+++ b/wazo_agentd/swagger/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import yaml
@@ -10,7 +10,6 @@ from xivo.http_helpers import reverse_proxy_fix_api_spec
 
 
 class SwaggerResource(Resource):
-
     api_package = "wazo_agentd.swagger"
     api_filename = "api.yml"
     api_path = "/api/api.yml"


### PR DESCRIPTION
Why:

* because we use the DAO directly in tests helpers and theres an incompatibility between SQLA versions

Incompatible change from 1.3 -> 1.4/2.X:
* `select` constructor changed and no longer receives a list

* breaks while importing CallFilter which relies on: `select([Extension.exten])`