### PR TITLE
agent: extract the agent-id from the interface

### DIFF
--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -11,7 +11,9 @@ class BusClient(bus_helper.BusClient):
             headers={'name': 'queue_deleted'},
         )
 
-    def send_queue_member_pause(self, agent_number, paused=True, queue_name=''):
+    def send_queue_member_pause(
+        self, agent_number, agent_id, paused=True, queue_name=''
+    ):
         self.publish(
             {
                 'data': {
@@ -19,6 +21,7 @@ class BusClient(bus_helper.BusClient):
                     'MemberName': f'local/{agent_number}',
                     'PausedReason': 'Eating potatoes',
                     'Queue': queue_name,
+                    'Interface': f'Local/id-{agent_id}@agentcallback',
                 },
                 'name': 'QueueMemberPause',
             },

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -130,7 +130,7 @@ class TestAgents(BaseIntegrationTest):
             # NOTE(fblackburn): agentd may be still not connected to the bus to receive messages
             # A best solution should be to create a /status and wait on it
             time.sleep(8)
-            self.bus.send_queue_member_pause('1234', paused=True)
+            self.bus.send_queue_member_pause('1234', agent['id'], paused=True)
 
             def test_on_msg_received():
                 status = self.agentd.agents.get_user_agent_status()
@@ -140,7 +140,7 @@ class TestAgents(BaseIntegrationTest):
 
             # unpause
             self.agentd.agents.unpause_user_agent()
-            self.bus.send_queue_member_pause('1234', paused=False)
+            self.bus.send_queue_member_pause('1234', agent['id'], paused=False)
 
             def test_on_msg_received():
                 status = self.agentd.agents.get_user_agent_status()

--- a/wazo_agentd/service/handler/on_queue.py
+++ b/wazo_agentd/service/handler/on_queue.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import re
 
 from wazo_agentd.service.helper import is_valid_agent_number
 
@@ -9,6 +10,8 @@ from xivo import debug
 from xivo_dao.helpers import db_utils
 
 logger = logging.getLogger(__name__)
+
+AGENT_ID_FROM_IFACE = re.compile(r'^Local/id-(\d+)@agentcallback$')
 
 
 class OnQueueHandler:
@@ -85,6 +88,6 @@ class OnQueueHandler:
             return
         reason = msg['PausedReason']
         queue = msg['Queue']
-        with db_utils.session_scope():
-            agent = self._agent_dao.agent_with_number(agent_number)
-        return agent.id, agent_number, reason, queue
+        if matches := AGENT_ID_FROM_IFACE.match(msg['Interface']):
+            agent_id = matches.group(1)
+            return agent_id, agent_number, reason, queue

--- a/wazo_agentd/service/handler/on_queue.py
+++ b/wazo_agentd/service/handler/on_queue.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -89,5 +89,5 @@ class OnQueueHandler:
         reason = msg['PausedReason']
         queue = msg['Queue']
         if matches := AGENT_ID_FROM_IFACE.match(msg['Interface']):
-            agent_id = matches.group(1)
+            agent_id = int(matches.group(1))
             return agent_id, agent_number, reason, queue

--- a/wazo_agentd/service/handler/tests/test_pause.py
+++ b/wazo_agentd/service/handler/tests/test_pause.py
@@ -44,33 +44,65 @@ class TestPauseHandler(unittest.TestCase):
                 'MemberName': 'aa/invalid-number-42',
                 'PausedReason': 'a',
                 'Queue': 'queue-1',
+                'Interface': 'Local/id-2@agentcallback',
             }
         )
         self.on_queue_pause_manager.on_queue_agent_paused.assert_not_called()
         self.agent_dao.agent_with_number.assert_not_called()
 
         self.on_queue_handler.handle_on_agent_paused(
-            {'MemberName': 'aa/42', 'PausedReason': 'a', 'Queue': 'queue-1'}
+            {
+                'MemberName': 'aa/42',
+                'PausedReason': 'a',
+                'Queue': 'queue-1',
+                'Interface': 'PJSIP/notanagent',
+            }
+        )
+        self.on_queue_pause_manager.on_queue_agent_paused.assert_not_called()
+        self.agent_dao.agent_with_number.assert_not_called()
+
+        self.on_queue_handler.handle_on_agent_paused(
+            {
+                'MemberName': 'aa/42',
+                'PausedReason': 'a',
+                'Queue': 'queue-1',
+                'Interface': 'Local/id-2@agentcallback',
+            }
         )
         self.on_queue_pause_manager.on_queue_agent_paused.assert_called_once()
-        self.agent_dao.agent_with_number.assert_called_once_with('42')
 
     def test_unpause_queue_agent(self):
         self.on_queue_handler.handle_on_agent_unpaused(
             {
-                'MemberName': 'aa/invalid-number-42',
+                'MemberName': 'aa/42',
                 'PausedReason': 'a',
                 'Queue': 'queue-1',
+                'Interface': 'PJSIP/notanagent',
             }
         )
         self.on_queue_pause_manager.on_queue_agent_unpaused.assert_not_called()
         self.agent_dao.agent_with_number.assert_not_called()
 
         self.on_queue_handler.handle_on_agent_unpaused(
-            {'MemberName': 'aa/42', 'PausedReason': 'a', 'Queue': 'queue-1'}
+            {
+                'MemberName': 'aa/invalid-number-42',
+                'PausedReason': 'a',
+                'Queue': 'queue-1',
+                'Interface': 'Local/id-2@agentcallback',
+            }
+        )
+        self.on_queue_pause_manager.on_queue_agent_unpaused.assert_not_called()
+        self.agent_dao.agent_with_number.assert_not_called()
+
+        self.on_queue_handler.handle_on_agent_unpaused(
+            {
+                'MemberName': 'aa/42',
+                'PausedReason': 'a',
+                'Queue': 'queue-1',
+                'Interface': 'Local/id-2@agentcallback',
+            }
         )
         self.on_queue_pause_manager.on_queue_agent_unpaused.assert_called_once()
-        self.agent_dao.agent_with_number.assert_called_once_with('42')
 
     def test_unpause_by_number(self):
         agent_number = '42'


### PR DESCRIPTION
use the interface of the login instead of querying the db by agent number