### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ kombu==5.0.2
 itsdangerous==1.1.0  # from flask
 jinja2==3.0.3  # from flask
 markupsafe==2.0.1 # from jinja
-marshmallow==3.10.0
+marshmallow==3.18.0
 netifaces==0.10.9
 psycopg2-binary==2.8.6  # from xivo-dao
 python-consul==1.1.0

--- a/wazo_agentd/plugins/agent/schemas.py
+++ b/wazo_agentd/plugins/agent/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields, validate
@@ -16,7 +16,7 @@ class UserAgentLoginSchema(Schema):
 
 class PauseSchema(Schema):
     reason = fields.String(
-        validate=validate.Length(min=1, max=80), missing=None, default=None
+        validate=validate.Length(min=1, max=80), load_default=None, default=None
     )
 
 


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade