### PR TITLE
on agent deleted fix logoff

### DIFF
--- a/integration_tests/suite/test_event_handler.py
+++ b/integration_tests/suite/test_event_handler.py
@@ -47,5 +47,4 @@ class TestEventHandler(BaseIntegrationTest):
             assert_that(status.logged, is_(False))
 
         self.bus.send_agent_deleted_event(agent['id'])
-        time.sleep(0.5)
         until.assert_(check_agent_status, tries=10)

--- a/wazo_agentd/service/manager/on_agent_deleted.py
+++ b/wazo_agentd/service/manager/on_agent_deleted.py
@@ -14,13 +14,12 @@ class OnAgentDeletedManager:
         self._agent_status_dao = agent_status_dao
 
     def on_agent_deleted(self, agent_id):
-        logger.debug('on_agent_deleted: %d', agent_id)
         with db_utils.session_scope():
             agent_status = (
                 self._agent_status_dao.get_agent_login_status_by_id_for_logoff(agent_id)
             )
-            logger.debug('agent_status: %s', str(agent_status))
         if agent_status is None:
+            logger.debug('agent %d has no active status requiring logoff', agent_id)
             return
 
         self._logoff_action.logoff_agent(agent_status)


### PR DESCRIPTION
- **test_event_handler: remove sleep**
- **on_agent_deleted: change logging**

Depends-On: https://github.com/wazo-platform/xivo-dao/pull/316