### PR TITLE
[ITEM-237] logoff agent when logging off last queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
   * POST `/agents/relog`
 
+* Logging an agent off from their last remaining queue now also logs the agent
+  off entirely.
+
+  * PUT `/agents/{agent_id}/queues/{queue_id}/logoff`
+  * PUT `/users/me/agents/queues/{queue_id}/logoff`
+
 ## 25.17
 
 * Added endpoints for user agents to login/logoff of its queues

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -514,14 +514,16 @@ class TestAgents(BaseIntegrationTest):
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()
     @fixtures.queue()
-    def test_logoff_agent_from_queue(self, user_line_extension, agent, queue):
+    @fixtures.queue()
+    def test_logoff_agent_from_queue(self, user_line_extension, agent, queue1, queue2):
         self.agentd.agents.login_agent(
             agent['id'],
             user_line_extension['exten'],
             user_line_extension['context'],
         )
 
-        self.agentd.agents.add_agent_to_queue(agent['id'], queue['id'])
+        self.agentd.agents.add_agent_to_queue(agent['id'], queue1['id'])
+        self.agentd.agents.add_agent_to_queue(agent['id'], queue2['id'])
 
         status = self.agentd.agents.get_agent_status(agent['id'])
         assert status.logged is True
@@ -530,14 +532,14 @@ class TestAgents(BaseIntegrationTest):
         accumulator = self.bus.accumulator(
             headers={'name': 'user_agent_queue_logged_off'}
         )
-        self.agentd.agents.agent_logoff_from_queue(agent['id'], queue['id'])
+        self.agentd.agents.agent_logoff_from_queue(agent['id'], queue1['id'])
 
         accumulator.until_assert_that_accumulate(
             has_items(
                 has_entries(
                     data=has_entries(
                         agent_id=agent['id'],
-                        queue_id=queue['id'],
+                        queue_id=queue1['id'],
                     ),
                 ),
             )

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -509,8 +509,7 @@ class TestAgents(BaseIntegrationTest):
             )
 
             status = self.agentd.agents.get_agent_status(agent['id'])
-            assert status.logged is True
-            assert status.queues[0]['logged'] is False
+            assert status.logged is False
 
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()
@@ -607,8 +606,8 @@ class TestAgents(BaseIntegrationTest):
             assert status.queues[0]['logged'] is True
             assert status.queues[1]['logged'] is False
 
-            self.agentd.agents.user_agent_logoff_from_queue(queue_1['id'])
             self.agentd.agents.user_agent_login_to_queue(queue_2['id'])
+            self.agentd.agents.user_agent_logoff_from_queue(queue_1['id'])
             self.agentd.agents.logoff_agent(agent['id'])
 
             status = self.agentd.agents.get_agent_status(agent['id'])

--- a/wazo_agentd/main.py
+++ b/wazo_agentd/main.py
@@ -131,6 +131,7 @@ def _run(config):
     queue_manager = QueueManager(
         add_to_queue_action,
         remove_from_queue_action,
+        logoff_action,
         agent_status_dao,
         user_dao,
         bus_publisher,

--- a/wazo_agentd/service/manager/queue.py
+++ b/wazo_agentd/service/manager/queue.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, TypeAlias
 
 from wazo_bus.resources.user_agent.event import (
@@ -25,11 +26,14 @@ if TYPE_CHECKING:
     from wazo_agentd.bus import BusPublisher
     from wazo_agentd.dao import _Queue as Queue
     from wazo_agentd.service.action.add import AddToQueueAction
+    from wazo_agentd.service.action.logoff import LogoffAction
     from wazo_agentd.service.action.remove import RemoveFromQueueAction
 
     Agent: TypeAlias = AgentDAO._Agent
     AgentStatus: TypeAlias = AgentStatusDAO._AgentStatus
     QueueStatus: TypeAlias = AgentStatusDAO._Queue
+
+logger = logging.getLogger(__name__)
 
 
 class QueueManager:
@@ -37,12 +41,14 @@ class QueueManager:
         self,
         add_to_queue_action: AddToQueueAction,
         remove_from_queue_action: RemoveFromQueueAction,
+        logoff_action: LogoffAction,
         agent_status_dao: AgentStatusDAO,
         user_dao: UserDAO,
         bus_publisher: BusPublisher,
     ):
         self._add_to_queue_action = add_to_queue_action
         self._remove_from_queue_action = remove_from_queue_action
+        self._logoff_action = logoff_action
         self._agent_status_dao = agent_status_dao
         self._user_dao = user_dao
         self._bus_publisher = bus_publisher
@@ -107,3 +113,12 @@ class QueueManager:
                 agent_status, agent_queue
             )
             self._send_bus_event(UserAgentQueueLoggedOffEvent, agent, agent_queue)
+
+            with db_utils.session_scope():
+                agent_status = self._agent_status_dao.get_status(agent.id)
+
+            if agent_status and not any(q.logged for q in agent_status.queues):
+                logger.info(
+                    'Agent %s has no remaining logged queues, logging off', agent.id
+                )
+                self._logoff_action.logoff_agent(agent_status)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core agent session behavior by triggering a full agent logoff when their last logged queue is removed, which could impact call-center availability if queue status tracking is wrong.
> 
> **Overview**
> When an agent is logged off from a queue and that was their **last remaining logged queue**, the system now automatically logs the agent off entirely (applies to both admin and `users/me` queue logoff endpoints).
> 
> This wires `LogoffAction` into `QueueManager.logoff_from_queue` and updates integration tests and the changelog to reflect the new behavior (agent `status.logged` becomes `False` after last-queue logoff, while logoff of one queue among multiple keeps the agent logged in).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 270616af5cb9a1c0404afa6026006fdb86a81d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->