### PR TITLE
[TASK-254] agent login all queues if no previous logged in queue

### DIFF
--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -525,3 +525,58 @@ class TestAgents(BaseIntegrationTest):
                     break
             else:
                 raise AssertionError('No such AMI QueueAdd event')
+
+    @fixtures.user_line_extension(exten='1001', context='default')
+    @fixtures.agent()
+    @fixtures.queue()
+    @fixtures.queue()
+    def test_login_with_no_previously_logged_queues_logs_into_all(
+        self, user_line_extension, agent, queue_1, queue_2
+    ):
+        with associations.user_agent(
+            self.database, user_line_extension['user_id'], agent['id']
+        ):
+            with self.database.queries() as db:
+                db.associate_queue_agent(queue_1['id'], agent['id'])
+                db.associate_queue_agent(queue_2['id'], agent['id'])
+                assert (
+                    db.get_agent_membership_status(queue_1['id'], agent['id']) is None
+                )
+                assert (
+                    db.get_agent_membership_status(queue_2['id'], agent['id']) is None
+                )
+
+            status = self.agentd.agents.get_agent_status(agent['id'])
+            assert status.logged is False
+
+            accumulator = self.bus.accumulator(
+                headers={'name': 'user_agent_queue_logged_in'}
+            )
+
+            self.agentd.agents.login_agent(
+                agent['id'],
+                user_line_extension['exten'],
+                user_line_extension['context'],
+            )
+
+            status = self.agentd.agents.get_agent_status(agent['id'])
+            assert status.logged is True
+            assert status.queues[0]['logged'] is True
+            assert status.queues[1]['logged'] is True
+
+            accumulator.until_assert_that_accumulate(
+                has_items(
+                    has_entries(
+                        data=has_entries(
+                            agent_id=agent['id'],
+                            queue_id=queue_1['id'],
+                        ),
+                    ),
+                    has_entries(
+                        data=has_entries(
+                            agent_id=agent['id'],
+                            queue_id=queue_2['id'],
+                        ),
+                    ),
+                )
+            )

--- a/wazo_agentd/dao.py
+++ b/wazo_agentd/dao.py
@@ -1,15 +1,13 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from collections import namedtuple
+from xivo_dao.agent_dao import _Queue
 
 from wazo_agentd.exception import (
     NoSuchAgentError,
     NoSuchExtenFeatureError,
     NoSuchQueueError,
 )
-
-_Queue = namedtuple('_Queue', ['id', 'tenant_uuid', 'name', 'penalty'])
 
 
 class _AbstractDAOAdapter:

--- a/wazo_agentd/main.py
+++ b/wazo_agentd/main.py
@@ -114,16 +114,8 @@ def _run(config):
     queue_log_manager = QueueLogManager(queue_log_dao)
 
     add_to_queue_action = AddToQueueAction(amid_client, agent_status_dao)
-    login_action = LoginAction(
-        amid_client,
-        queue_log_manager,
-        blf_manager,
-        agent_status_dao,
-        line_dao,
-        user_dao,
-        agent_dao,
-        bus_publisher,
-    )
+    remove_from_queue_action = RemoveFromQueueAction(amid_client, agent_status_dao)
+    update_penalty_action = UpdatePenaltyAction(amid_client, agent_status_dao)
     pause_action = PauseAction(amid_client)
     pause_manager = PauseManager(pause_action, agent_dao)
     logoff_action = LogoffAction(
@@ -136,12 +128,28 @@ def _run(config):
         agent_dao,
         bus_publisher,
     )
-    remove_from_queue_action = RemoveFromQueueAction(amid_client, agent_status_dao)
-    update_penalty_action = UpdatePenaltyAction(amid_client, agent_status_dao)
-
+    queue_manager = QueueManager(
+        add_to_queue_action,
+        remove_from_queue_action,
+        agent_status_dao,
+        user_dao,
+        bus_publisher,
+    )
+    login_action = LoginAction(
+        amid_client,
+        queue_log_manager,
+        blf_manager,
+        agent_status_dao,
+        line_dao,
+        user_dao,
+        agent_dao,
+        bus_publisher,
+        queue_manager,
+    )
     add_member_manager = AddMemberManager(
         add_to_queue_action, amid_client, queue_member_dao
     )
+
     login_manager = LoginManager(login_action, agent_status_dao, context_dao, line_dao)
     logoff_manager = LogoffManager(logoff_action, agent_dao, agent_status_dao)
     on_agent_deleted_manager = OnAgentDeletedManager(logoff_manager, agent_status_dao)
@@ -161,13 +169,6 @@ def _run(config):
     )
     remove_member_manager = RemoveMemberManager(
         remove_from_queue_action, amid_client, queue_member_dao
-    )
-    queue_manager = QueueManager(
-        add_to_queue_action,
-        remove_from_queue_action,
-        agent_status_dao,
-        user_dao,
-        bus_publisher,
     )
     on_queue_member_associated_manager = OnQueueMemberAssociatedManager(
         add_to_queue_action

--- a/wazo_agentd/service/action/login.py
+++ b/wazo_agentd/service/action/login.py
@@ -79,8 +79,8 @@ class LoginAction:
             enabled_queues = self._agent_dao.list_agent_enabled_queues(agent.id)
         self._update_asterisk(agent, interface, state_interface, enabled_queues)
         self._update_blf(agent)
-        self._ensure_queues_logged_in(agent, enabled_queues)
         self._send_bus_status_update(agent)
+        self._ensure_queues_logged_in(agent, enabled_queues)
 
     def _ensure_queues_logged_in(self, agent: Agent, enabled_queues):
         if enabled_queues or not agent.queues:

--- a/wazo_agentd/service/action/login.py
+++ b/wazo_agentd/service/action/login.py
@@ -75,14 +75,14 @@ class LoginAction:
     def _do_login(self, agent, extension, context, interface, state_interface):
         self._update_agent_status(agent, extension, context, interface, state_interface)
         self._update_queue_log(agent, extension, context)
-        self._update_asterisk(agent, interface, state_interface)
-        self._update_blf(agent)
-        self._ensure_queues_logged_in(agent)
-        self._send_bus_status_update(agent)
-
-    def _ensure_queues_logged_in(self, agent: Agent):
         with db_utils.session_scope():
             enabled_queues = self._agent_dao.list_agent_enabled_queues(agent.id)
+        self._update_asterisk(agent, interface, state_interface, enabled_queues)
+        self._update_blf(agent)
+        self._ensure_queues_logged_in(agent, enabled_queues)
+        self._send_bus_status_update(agent)
+
+    def _ensure_queues_logged_in(self, agent: Agent, enabled_queues):
         if enabled_queues or not agent.queues:
             return
         logger.info(
@@ -131,10 +131,9 @@ class LoginAction:
     def _update_queue_log(self, agent, extension, context):
         self._queue_log_manager.on_agent_logged_in(agent.number, extension, context)
 
-    def _update_asterisk(self, agent: Agent, interface, state_interface):
-        with db_utils.session_scope():
-            enabled_queues = self._agent_dao.list_agent_enabled_queues(agent.id)
-
+    def _update_asterisk(
+        self, agent: Agent, interface, state_interface, enabled_queues
+    ):
         member_name = format_agent_member_name(agent.number)
         skills = format_agent_skills(agent.id)
         for queue in enabled_queues:

--- a/wazo_agentd/service/action/login.py
+++ b/wazo_agentd/service/action/login.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, TypeAlias
 
 from wazo_amid_client.exceptions import AmidProtocolError
 from wazo_bus.resources.agent.event import AgentStatusUpdatedEvent
+from wazo_bus.resources.user_agent.event import UserAgentQueueLoggedInEvent
 from xivo_dao.helpers import db_utils
 
 from wazo_agentd.exception import NoSuchExtensionError, NoSuchLineError
@@ -71,9 +72,31 @@ class LoginAction:
     def _do_login(self, agent, extension, context, interface, state_interface):
         self._update_agent_status(agent, extension, context, interface, state_interface)
         self._update_queue_log(agent, extension, context)
+        self._ensure_queues_logged_in(agent)
         self._update_asterisk(agent, interface, state_interface)
         self._update_blf(agent)
         self._send_bus_status_update(agent)
+
+    def _ensure_queues_logged_in(self, agent: Agent):
+        with db_utils.session_scope():
+            enabled_queues = self._agent_dao.list_agent_enabled_queues(agent.id)
+            if enabled_queues or not agent.queues:
+                return
+            logger.info(
+                'Agent %s has no previously logged queues, '
+                'logging into all assigned queues',
+                agent.id,
+            )
+            self._agent_status_dao.add_agent_to_queues(agent.id, agent.queues)
+            user_uuids = [
+                user.uuid for user in self._user_dao.find_all_by_agent_id(agent.id)
+            ]
+
+        for queue in agent.queues:
+            event = UserAgentQueueLoggedInEvent(
+                agent.id, queue.id, agent.tenant_uuid, user_uuids
+            )
+            self._bus_publisher.publish(event)
 
     def _get_interface(self, agent):
         return f'Local/id-{agent.id}@agentcallback'

--- a/wazo_agentd/service/action/login.py
+++ b/wazo_agentd/service/action/login.py
@@ -91,7 +91,15 @@ class LoginAction:
             agent.id,
         )
         for queue in agent.queues:
-            self._queue_manager.login_to_queue(agent, queue)
+            try:
+                self._queue_manager.login_to_queue(agent, queue)
+            except Exception as e:
+                logger.warning(
+                    'Failure to login agent %r to queue %r: %s',
+                    agent.id,
+                    queue.name,
+                    e,
+                )
 
     def _get_interface(self, agent):
         return f'Local/id-{agent.id}@agentcallback'

--- a/wazo_agentd/service/action/login.py
+++ b/wazo_agentd/service/action/login.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, TypeAlias
 
 from wazo_amid_client.exceptions import AmidProtocolError
 from wazo_bus.resources.agent.event import AgentStatusUpdatedEvent
-from wazo_bus.resources.user_agent.event import UserAgentQueueLoggedInEvent
 from xivo_dao.helpers import db_utils
 
 from wazo_agentd.exception import NoSuchExtensionError, NoSuchLineError
@@ -19,6 +18,7 @@ if TYPE_CHECKING:
     from xivo_dao.agent_dao import _Agent as Agent
 
     from wazo_agentd.dao import AgentDAOAdapter as AgentDAO
+    from wazo_agentd.service.manager.queue import QueueManager
 
     AgentStatus: TypeAlias = AgentStatusDAO._AgentStatus
 
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 class LoginAction:
     _agent_dao: AgentDAO
     _agent_status_dao: AgentStatusDAO
+    _queue_manager: QueueManager
 
     def __init__(
         self,
@@ -39,6 +40,7 @@ class LoginAction:
         user_dao,
         agent_dao,
         bus_publisher,
+        queue_manager,
     ):
         self._amid_client = amid_client
         self._blf_manager = blf_manager
@@ -48,6 +50,7 @@ class LoginAction:
         self._user_dao = user_dao
         self._agent_dao = agent_dao
         self._bus_publisher = bus_publisher
+        self._queue_manager = queue_manager
 
     def login_agent(self, agent, extension, context, endpoint=None):
         # Precondition:
@@ -72,31 +75,23 @@ class LoginAction:
     def _do_login(self, agent, extension, context, interface, state_interface):
         self._update_agent_status(agent, extension, context, interface, state_interface)
         self._update_queue_log(agent, extension, context)
-        self._ensure_queues_logged_in(agent)
         self._update_asterisk(agent, interface, state_interface)
         self._update_blf(agent)
+        self._ensure_queues_logged_in(agent)
         self._send_bus_status_update(agent)
 
     def _ensure_queues_logged_in(self, agent: Agent):
         with db_utils.session_scope():
             enabled_queues = self._agent_dao.list_agent_enabled_queues(agent.id)
-            if enabled_queues or not agent.queues:
-                return
-            logger.info(
-                'Agent %s has no previously logged queues, '
-                'logging into all assigned queues',
-                agent.id,
-            )
-            self._agent_status_dao.add_agent_to_queues(agent.id, agent.queues)
-            user_uuids = [
-                user.uuid for user in self._user_dao.find_all_by_agent_id(agent.id)
-            ]
-
+        if enabled_queues or not agent.queues:
+            return
+        logger.info(
+            'Agent %s has no previously logged queues, '
+            'logging into all assigned queues',
+            agent.id,
+        )
         for queue in agent.queues:
-            event = UserAgentQueueLoggedInEvent(
-                agent.id, queue.id, agent.tenant_uuid, user_uuids
-            )
-            self._bus_publisher.publish(event)
+            self._queue_manager.login_to_queue(agent, queue)
 
     def _get_interface(self, agent):
         return f'Local/id-{agent.id}@agentcallback'

--- a/wazo_agentd/service/action/tests/test_login.py
+++ b/wazo_agentd/service/action/tests/test_login.py
@@ -23,6 +23,7 @@ class TestLoginAction(unittest.TestCase):
         self.user_dao = Mock()
         self.agent_dao = Mock()
         self.bus_publisher = Mock()
+        self.queue_manager = Mock()
         self.login_action = LoginAction(
             self.amid_client,
             self.queue_log_manager,
@@ -32,6 +33,7 @@ class TestLoginAction(unittest.TestCase):
             self.user_dao,
             self.agent_dao,
             self.bus_publisher,
+            self.queue_manager,
         )
 
     def test_login_agent(self):
@@ -218,20 +220,14 @@ class TestLoginAction(unittest.TestCase):
         ]
         self.amid_client.action.return_value = [{'Response': 'Ok'}]
         self.agent_dao.agent_with_id.return_value = Mock(tenant_uuid=tenant_uuid)
-        # Fallback sequence: no enabled queues on first call (triggers fallback),
-        # then agent.queues after add_agent_to_queues populates them.
-        self.agent_dao.list_agent_enabled_queues.side_effect = [[], [queue1, queue2]]
+        self.agent_dao.list_agent_enabled_queues.return_value = []
 
         self.login_action.login_agent(agent, extension, context)
 
-        self.agent_status_dao.add_agent_to_queues.assert_called_once_with(
-            agent_id, [queue1, queue2]
+        assert_that(
+            self.queue_manager.login_to_queue.call_args_list,
+            contains_inanyorder(call(agent, queue1), call(agent, queue2)),
         )
-
-        queue_names_added = [
-            c.args[1]['Queue'] for c in self.amid_client.action.call_args_list
-        ]
-        assert_that(queue_names_added, contains_inanyorder(queue1.name, queue2.name))
 
     def test_login_agent_with_no_queues_assigned_does_not_enable_any(self):
         agent_id = 10

--- a/wazo_agentd/service/action/tests/test_login.py
+++ b/wazo_agentd/service/action/tests/test_login.py
@@ -65,6 +65,7 @@ class TestLoginAction(unittest.TestCase):
         self.agent_status_dao.log_in_agent.assert_called_once_with(
             agent_id, agent_number, extension, context, ANY, state_interface_sip
         )
+        self.agent_status_dao.add_agent_to_queues.assert_not_called()
         self.queue_log_manager.on_agent_logged_in.assert_called_once_with(
             agent_number, extension, context
         )
@@ -191,3 +192,68 @@ class TestLoginAction(unittest.TestCase):
             ),
         )
         self.bus_publisher.publish.assert_called_once_with(event)
+
+    def test_login_agent_with_no_previously_logged_queues_enables_all_queues(self):
+        agent_id = 10
+        agent_number = '10'
+        queue1 = Mock()
+        queue1.id = 101
+        queue2 = Mock()
+        queue2.id = 102
+        agent = Mock(user_ids=[], tenant_uuid='fake-tenant')
+        agent.id = agent_id
+        agent.number = agent_number
+        agent.queues = [queue1, queue2]
+        extension = '1001'
+        context = 'default'
+        state_interface_sip = 'PJSIP/abcd'
+        tenant_uuid = '00000000-0000-4000-8000-000000001234'
+
+        self.line_dao.get_interface_from_exten_and_context.return_value = (
+            state_interface_sip
+        )
+        self.user_dao.find_all_by_agent_id.return_value = [
+            Mock(uuid='42'),
+            Mock(uuid='43'),
+        ]
+        self.amid_client.action.return_value = [{'Response': 'Ok'}]
+        self.agent_dao.agent_with_id.return_value = Mock(tenant_uuid=tenant_uuid)
+        # Fallback sequence: no enabled queues on first call (triggers fallback),
+        # then agent.queues after add_agent_to_queues populates them.
+        self.agent_dao.list_agent_enabled_queues.side_effect = [[], [queue1, queue2]]
+
+        self.login_action.login_agent(agent, extension, context)
+
+        self.agent_status_dao.add_agent_to_queues.assert_called_once_with(
+            agent_id, [queue1, queue2]
+        )
+
+        queue_names_added = [
+            c.args[1]['Queue'] for c in self.amid_client.action.call_args_list
+        ]
+        assert_that(queue_names_added, contains_inanyorder(queue1.name, queue2.name))
+
+    def test_login_agent_with_no_queues_assigned_does_not_enable_any(self):
+        agent_id = 10
+        agent_number = '10'
+        agent = Mock(user_ids=[])
+        agent.id = agent_id
+        agent.number = agent_number
+        agent.queues = []
+        extension = '1001'
+        context = 'default'
+        state_interface_sip = 'PJSIP/abcd'
+        tenant_uuid = '00000000-0000-4000-8000-000000001234'
+
+        self.line_dao.get_interface_from_exten_and_context.return_value = (
+            state_interface_sip
+        )
+        self.user_dao.find_all_by_agent_id.return_value = []
+        self.amid_client.action.return_value = [{'Response': 'Ok'}]
+        self.agent_dao.agent_with_id.return_value = Mock(tenant_uuid=tenant_uuid)
+        self.agent_dao.list_agent_enabled_queues.return_value = []
+
+        self.login_action.login_agent(agent, extension, context)
+
+        self.agent_status_dao.add_agent_to_queues.assert_not_called()
+        self.amid_client.action.assert_not_called()

--- a/wazo_agentd/service/action/tests/test_login.py
+++ b/wazo_agentd/service/action/tests/test_login.py
@@ -68,6 +68,7 @@ class TestLoginAction(unittest.TestCase):
             agent_id, agent_number, extension, context, ANY, state_interface_sip
         )
         self.agent_status_dao.add_agent_to_queues.assert_not_called()
+        self.agent_dao.list_agent_enabled_queues.assert_called_once_with(agent_id)
         self.queue_log_manager.on_agent_logged_in.assert_called_once_with(
             agent_number, extension, context
         )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes agent login flow to implicitly log into all assigned queues when no prior queue membership state exists, which can affect call routing and queue membership behavior. Risk is moderate due to new side effects during login and reliance on `QueueManager`/bus events, but scoped to this edge case and covered by new tests.
> 
> **Overview**
> When an agent logs in and has **no previously enabled/logged queues**, the login flow now automatically logs the agent into *all queues assigned to them* (via `QueueManager.login_to_queue`), emitting the usual queue login bus events.
> 
> Wires `QueueManager` into `LoginAction` and adjusts startup wiring in `main.py`, and updates `_Queue` to reuse the DAO-provided type instead of a local `namedtuple`.
> 
> Adds unit + integration coverage for the new “no previous queue state” behavior and for the case where an agent has no queues assigned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b6ae2b752d17acaf864bae7d333948592f4e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->