### PR TITLE
TASK-250-admin-queue-login-v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 26.05
+
+* Added admin endpoints for per-queue agent login/logoff
+
+  * PUT `/agents/{agent_id}/queues/{queue_id}/login`
+  * PUT `/agents/{agent_id}/queues/{queue_id}/logoff`
+
 ## 25.17
 
 * Added endpoints for user agents to login/logoff of its queues

--- a/integration_tests/suite/helpers/database.py
+++ b/integration_tests/suite/helpers/database.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -142,9 +142,13 @@ class DatabaseQueries:
         with self.inserter() as inserter:
             queue = inserter.session.get(Queue, queue_id)
             agent = inserter.session.get(Agent, agent_id)
+            if agent.users and agent.users[0].lines:
+                interface = f'PJSIP/{agent.users[0].lines[0].endpoint_sip.name}'
+            else:
+                interface = f'Agent/{agent.number}'
             return inserter.add_queue_member(
                 queue_name=queue.name,
-                interface=f'PJSIP/{agent.users[0].lines[0].endpoint_sip.name}',
+                interface=interface,
                 usertype='agent',
                 category='queue',
                 channel='Agent',

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -405,6 +405,43 @@ class TestAgents(BaseIntegrationTest):
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()
     @fixtures.queue()
+    def test_admin_login_agent_to_queue(self, user_line_extension, agent, queue):
+        self.agentd.agents.login_agent(
+            agent['id'],
+            user_line_extension['exten'],
+            user_line_extension['context'],
+        )
+
+        with self.database.queries() as db:
+            db.associate_queue_agent(queue['id'], agent['id'])
+
+        status = self.agentd.agents.get_agent_status(agent['id'])
+        assert status.logged is True
+        assert status.queues[0]['logged'] is False
+
+        accumulator = self.bus.accumulator(
+            headers={'name': 'user_agent_queue_logged_in'}
+        )
+        self.agentd.agents.user_agent_login_to_queue(queue['id'], agent_id=agent['id'])
+
+        accumulator.until_assert_that_accumulate(
+            has_items(
+                has_entries(
+                    data=has_entries(
+                        agent_id=agent['id'],
+                        queue_id=queue['id'],
+                    ),
+                ),
+            )
+        )
+
+        status = self.agentd.agents.get_agent_status(agent['id'])
+        assert status.logged is True
+        assert status.queues[0]['logged'] is True
+
+    @fixtures.user_line_extension(exten='1001', context='default')
+    @fixtures.agent()
+    @fixtures.queue()
     def test_user_agent_logoff_from_queue(self, user_line_extension, agent, queue):
         self.agentd.agents.login_agent(
             agent['id'],

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -406,7 +406,7 @@ class TestAgents(BaseIntegrationTest):
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()
     @fixtures.queue()
-    def test_admin_login_agent_to_queue(self, user_line_extension, agent, queue):
+    def test_login_agent_to_queue(self, user_line_extension, agent, queue):
         self.agentd.agents.login_agent(
             agent['id'],
             user_line_extension['exten'],
@@ -441,7 +441,7 @@ class TestAgents(BaseIntegrationTest):
         assert status.queues[0]['logged'] is True
 
     @fixtures.queue()
-    def test_admin_login_agent_to_queue_unknown_agent(self, queue):
+    def test_login_agent_to_queue_unknown_agent(self, queue):
         assert_that(
             calling(self.agentd.agents.agent_login_to_queue).with_args(
                 UNKNOWN_ID, queue['id']
@@ -450,12 +450,25 @@ class TestAgents(BaseIntegrationTest):
         )
 
     @fixtures.agent()
-    def test_admin_login_agent_to_queue_unknown_queue(self, agent):
+    def test_login_agent_to_queue_unknown_queue(self, agent):
         assert_that(
             calling(self.agentd.agents.agent_login_to_queue).with_args(
                 agent['id'], UNKNOWN_ID
             ),
             raises(AgentdClientError, has_properties(error=NO_SUCH_QUEUE)),
+        )
+
+    @fixtures.agent()
+    @fixtures.queue()
+    def test_login_agent_to_queue_not_logged(self, agent, queue):
+        with self.database.queries() as db:
+            db.associate_queue_agent(queue['id'], agent['id'])
+
+        assert_that(
+            calling(self.agentd.agents.agent_login_to_queue).with_args(
+                agent['id'], queue['id']
+            ),
+            raises(AgentdClientError, has_properties(error=NOT_LOGGED)),
         )
 
     @fixtures.user_line_extension(exten='1001', context='default')
@@ -502,7 +515,7 @@ class TestAgents(BaseIntegrationTest):
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()
     @fixtures.queue()
-    def test_admin_logoff_agent_from_queue(self, user_line_extension, agent, queue):
+    def test_logoff_agent_from_queue(self, user_line_extension, agent, queue):
         self.agentd.agents.login_agent(
             agent['id'],
             user_line_extension['exten'],
@@ -536,7 +549,7 @@ class TestAgents(BaseIntegrationTest):
         assert status.queues[0]['logged'] is False
 
     @fixtures.queue()
-    def test_admin_logoff_agent_from_queue_unknown_agent(self, queue):
+    def test_logoff_agent_from_queue_unknown_agent(self, queue):
         assert_that(
             calling(self.agentd.agents.agent_logoff_from_queue).with_args(
                 UNKNOWN_ID, queue['id']
@@ -545,12 +558,25 @@ class TestAgents(BaseIntegrationTest):
         )
 
     @fixtures.agent()
-    def test_admin_logoff_agent_from_queue_unknown_queue(self, agent):
+    def test_logoff_agent_from_queue_unknown_queue(self, agent):
         assert_that(
             calling(self.agentd.agents.agent_logoff_from_queue).with_args(
                 agent['id'], UNKNOWN_ID
             ),
             raises(AgentdClientError, has_properties(error=NO_SUCH_QUEUE)),
+        )
+
+    @fixtures.agent()
+    @fixtures.queue()
+    def test_logoff_agent_from_queue_not_logged(self, agent, queue):
+        with self.database.queries() as db:
+            db.associate_queue_agent(queue['id'], agent['id'])
+
+        assert_that(
+            calling(self.agentd.agents.agent_logoff_from_queue).with_args(
+                agent['id'], queue['id']
+            ),
+            raises(AgentdClientError, has_properties(error=NOT_LOGGED)),
         )
 
     @fixtures.user_line_extension(exten='1001', context='default')

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -17,6 +17,7 @@ from wazo_agentd_client.error import (
     NO_SUCH_AGENT,
     NO_SUCH_EXTEN,
     NO_SUCH_LINE,
+    NO_SUCH_QUEUE,
     NOT_LOGGED,
     UNAUTHORIZED,
     AgentdClientError,
@@ -422,7 +423,7 @@ class TestAgents(BaseIntegrationTest):
         accumulator = self.bus.accumulator(
             headers={'name': 'user_agent_queue_logged_in'}
         )
-        self.agentd.agents.user_agent_login_to_queue(queue['id'], agent_id=agent['id'])
+        self.agentd.agents.agent_login_to_queue(agent['id'], queue['id'])
 
         accumulator.until_assert_that_accumulate(
             has_items(
@@ -438,6 +439,24 @@ class TestAgents(BaseIntegrationTest):
         status = self.agentd.agents.get_agent_status(agent['id'])
         assert status.logged is True
         assert status.queues[0]['logged'] is True
+
+    @fixtures.queue()
+    def test_admin_login_agent_to_queue_unknown_agent(self, queue):
+        assert_that(
+            calling(self.agentd.agents.agent_login_to_queue).with_args(
+                UNKNOWN_ID, queue['id']
+            ),
+            raises(AgentdClientError, has_properties(error=NO_SUCH_AGENT)),
+        )
+
+    @fixtures.agent()
+    def test_admin_login_agent_to_queue_unknown_queue(self, agent):
+        assert_that(
+            calling(self.agentd.agents.agent_login_to_queue).with_args(
+                agent['id'], UNKNOWN_ID
+            ),
+            raises(AgentdClientError, has_properties(error=NO_SUCH_QUEUE)),
+        )
 
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()
@@ -499,9 +518,7 @@ class TestAgents(BaseIntegrationTest):
         accumulator = self.bus.accumulator(
             headers={'name': 'user_agent_queue_logged_off'}
         )
-        self.agentd.agents.user_agent_logoff_from_queue(
-            queue['id'], agent_id=agent['id']
-        )
+        self.agentd.agents.agent_logoff_from_queue(agent['id'], queue['id'])
 
         accumulator.until_assert_that_accumulate(
             has_items(
@@ -517,6 +534,24 @@ class TestAgents(BaseIntegrationTest):
         status = self.agentd.agents.get_agent_status(agent['id'])
         assert status.logged is True
         assert status.queues[0]['logged'] is False
+
+    @fixtures.queue()
+    def test_admin_logoff_agent_from_queue_unknown_agent(self, queue):
+        assert_that(
+            calling(self.agentd.agents.agent_logoff_from_queue).with_args(
+                UNKNOWN_ID, queue['id']
+            ),
+            raises(AgentdClientError, has_properties(error=NO_SUCH_AGENT)),
+        )
+
+    @fixtures.agent()
+    def test_admin_logoff_agent_from_queue_unknown_queue(self, agent):
+        assert_that(
+            calling(self.agentd.agents.agent_logoff_from_queue).with_args(
+                agent['id'], UNKNOWN_ID
+            ),
+            raises(AgentdClientError, has_properties(error=NO_SUCH_QUEUE)),
+        )
 
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -483,6 +483,44 @@ class TestAgents(BaseIntegrationTest):
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()
     @fixtures.queue()
+    def test_admin_logoff_agent_from_queue(self, user_line_extension, agent, queue):
+        self.agentd.agents.login_agent(
+            agent['id'],
+            user_line_extension['exten'],
+            user_line_extension['context'],
+        )
+
+        self.agentd.agents.add_agent_to_queue(agent['id'], queue['id'])
+
+        status = self.agentd.agents.get_agent_status(agent['id'])
+        assert status.logged is True
+        assert status.queues[0]['logged'] is True
+
+        accumulator = self.bus.accumulator(
+            headers={'name': 'user_agent_queue_logged_off'}
+        )
+        self.agentd.agents.user_agent_logoff_from_queue(
+            queue['id'], agent_id=agent['id']
+        )
+
+        accumulator.until_assert_that_accumulate(
+            has_items(
+                has_entries(
+                    data=has_entries(
+                        agent_id=agent['id'],
+                        queue_id=queue['id'],
+                    ),
+                ),
+            )
+        )
+
+        status = self.agentd.agents.get_agent_status(agent['id'])
+        assert status.logged is True
+        assert status.queues[0]['logged'] is False
+
+    @fixtures.user_line_extension(exten='1001', context='default')
+    @fixtures.agent()
+    @fixtures.queue()
     @fixtures.queue()
     def test_agent_login_logoff_preserves_queue_status(
         self, user_line_extension, agent, queue_1, queue_2

--- a/wazo_agentd/plugins/agent/api.yml
+++ b/wazo_agentd/plugins/agent/api.yml
@@ -370,11 +370,7 @@ paths:
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
-      - name: queue_id
-        type: integer
-        in: path
-        required: true
-        description: Queue's ID
+      - $ref: '#/parameters/QueueID'
       responses:
         '204':
           description: The operation was performed succesfully
@@ -392,11 +388,7 @@ paths:
       - user
       parameters:
       - $ref: '#/parameters/tenantuuid'
-      - name: queue_id
-        type: integer
-        in: path
-        required: true
-        description: Queue's ID
+      - $ref: '#/parameters/QueueID'
       responses:
         '204':
           description: The operation was performed succesfully
@@ -418,11 +410,7 @@ paths:
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
-      - name: queue_id
-        type: integer
-        in: path
-        required: true
-        description: Queue's ID
+      - $ref: '#/parameters/QueueID'
       responses:
         '204':
           description: The operation was performed succesfully
@@ -440,11 +428,7 @@ paths:
       - user
       parameters:
       - $ref: '#/parameters/tenantuuid'
-      - name: queue_id
-        type: integer
-        in: path
-        required: true
-        description: Queue's ID
+      - $ref: '#/parameters/QueueID'
       responses:
         '204':
           description: The operation was performed succesfully
@@ -463,6 +447,12 @@ parameters:
     type: integer
     required: true
     description: Agent's ID
+  QueueID:
+    name: queue_id
+    in: path
+    type: integer
+    required: true
+    description: Queue's ID
   recurse:
     name: recurse
     in: query

--- a/wazo_agentd/plugins/agent/api.yml
+++ b/wazo_agentd/plugins/agent/api.yml
@@ -360,6 +360,28 @@ paths:
           description: Agent is not a member of the queue
           schema:
             $ref: '#/definitions/Error'
+  /agents/{agent_id}/queues/{queue_id}/login:
+    put:
+      summary: Login agent to queue
+      description: '**Required ACL:** `agentd.agents.{agent_id}.queues.{queue_id}.login.update`'
+      operationId: login_agent_to_queue
+      tags:
+      - agent
+      parameters:
+      - $ref: '#/parameters/tenantuuid'
+      - $ref: '#/parameters/AgentID'
+      - name: queue_id
+        type: integer
+        in: path
+        required: true
+        description: Queue's ID
+      responses:
+        '204':
+          description: The operation was performed succesfully
+        '404':
+          description: Agent or queue does not exist
+          schema:
+            $ref: '#/definitions/Error'
   /users/me/agents/queues/{queue_id}/login:
     put:
       summary: Login user agent to queue

--- a/wazo_agentd/plugins/agent/api.yml
+++ b/wazo_agentd/plugins/agent/api.yml
@@ -374,8 +374,16 @@ paths:
       responses:
         '204':
           description: The operation was performed successfully
+        '400':
+          description: The agent and the queue are not in the same tenant
+          schema:
+            $ref: '#/definitions/Error'
         '404':
           description: Agent or queue does not exist
+          schema:
+            $ref: '#/definitions/Error'
+        '409':
+          description: Agent is not logged
           schema:
             $ref: '#/definitions/Error'
   /users/me/agents/queues/{queue_id}/login:
@@ -400,6 +408,10 @@ paths:
           description: Agent or queue does not exist
           schema:
             $ref: '#/definitions/Error'
+        '409':
+          description: Agent is not logged
+          schema:
+            $ref: '#/definitions/Error'
   /agents/{agent_id}/queues/{queue_id}/logoff:
     put:
       summary: Logoff agent from queue
@@ -414,8 +426,16 @@ paths:
       responses:
         '204':
           description: The operation was performed successfully
+        '400':
+          description: The agent and the queue are not in the same tenant
+          schema:
+            $ref: '#/definitions/Error'
         '404':
           description: Agent or queue does not exist
+          schema:
+            $ref: '#/definitions/Error'
+        '409':
+          description: Agent is not logged
           schema:
             $ref: '#/definitions/Error'
   /users/me/agents/queues/{queue_id}/logoff:
@@ -438,6 +458,10 @@ paths:
             $ref: '#/definitions/Error'
         '404':
           description: Agent or queue does not exist
+          schema:
+            $ref: '#/definitions/Error'
+        '409':
+          description: Agent is not logged
           schema:
             $ref: '#/definitions/Error'
 parameters:

--- a/wazo_agentd/plugins/agent/api.yml
+++ b/wazo_agentd/plugins/agent/api.yml
@@ -5,7 +5,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-id.{agent_id}.read`'
       operationId: get_agent_by_id
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
@@ -24,7 +24,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-number.{agent_number}.read`'
       operationId: get_agent_by_number
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentNumber'
@@ -43,7 +43,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-id.{agent_id}.login.create`'
       operationId: login_agent_by_id
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
@@ -75,7 +75,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-number.{agent_number}.login.create`'
       operationId: login_agent_by_number
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentNumber'
@@ -107,8 +107,8 @@ paths:
       description: '**Required ACL:** `agentd.users.me.agents.read`'
       operationId: get_user_agent
       tags:
-      - agent
-      - user
+      - agents
+      - users
       parameters:
       - $ref: '#/parameters/tenantuuid'
       responses:
@@ -126,8 +126,8 @@ paths:
       description: '**Required ACL:** `agentd.users.me.agents.login.create`'
       operationId: login_user_agent
       tags:
-      - agent
-      - user
+      - agents
+      - users
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - name: body
@@ -154,7 +154,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-id.{agent_id}.logoff.create`'
       operationId: logoff_agent_by_id
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
@@ -171,7 +171,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-number.{agent_number}.logoff.create`'
       operationId: logoff_agent_by_number
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentNumber'
@@ -188,8 +188,8 @@ paths:
       description: '**Required ACL:** `agentd.users.me.agents.logoff.create`'
       operationId: logoff_user_agent
       tags:
-      - agent
-      - user
+      - agents
+      - users
       parameters:
       - $ref: '#/parameters/tenantuuid'
       responses:
@@ -210,7 +210,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-number.{agent_number}.pause.create`'
       operationId: pause_agent_by_number
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentNumber'
@@ -237,8 +237,8 @@ paths:
       description: '**Required ACL:** `agentd.users.me.agents.pause.create`'
       operationId: pause_user_agent
       tags:
-      - agent
-      - user
+      - agents
+      - users
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - name: body
@@ -265,7 +265,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-number.{agent_number}.unpause.create`'
       operationId: unpause_agent_by_number
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentNumber'
@@ -286,8 +286,8 @@ paths:
       description: '**Required ACL:** `agentd.users.me.agents.unpause.create`'
       operationId: unpause_user_agent
       tags:
-      - agent
-      - user
+      - agents
+      - users
       parameters:
       - $ref: '#/parameters/tenantuuid'
       responses:
@@ -308,7 +308,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-id.{agent_id}.add.create`'
       operationId: add_agent_by_id
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
@@ -339,7 +339,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.by-id.{agent_id}.remove.create`'
       operationId: remove_agent_by_id
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
@@ -366,7 +366,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.{agent_id}.queues.{queue_id}.login.update`'
       operationId: login_agent_to_queue
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
@@ -384,8 +384,8 @@ paths:
       description: '**Required ACL:** `agentd.users.me.agents.queues.{queue_id}.login.update`'
       operationId: user_agent_login_to_queue
       tags:
-      - agent
-      - user
+      - agents
+      - users
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/QueueID'
@@ -406,7 +406,7 @@ paths:
       description: '**Required ACL:** `agentd.agents.{agent_id}.queues.{queue_id}.logoff.update`'
       operationId: logoff_agent_from_queue
       tags:
-      - agent
+      - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/AgentID'
@@ -424,8 +424,8 @@ paths:
       description: '**Required ACL:** `agentd.users.me.agents.queues.{queue_id}.logoff.update`'
       operationId: user_agent_logoff_from_queue
       tags:
-      - agent
-      - user
+      - agents
+      - users
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/QueueID'

--- a/wazo_agentd/plugins/agent/api.yml
+++ b/wazo_agentd/plugins/agent/api.yml
@@ -55,7 +55,7 @@ paths:
           $ref: '#/definitions/LoginInfo'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '400':
           description: The context and extension are not in the same tenant as the agent
           schema:
@@ -87,7 +87,7 @@ paths:
           $ref: '#/definitions/LoginInfo'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '400':
           description: The context and extension are not in the same tenant as the agent
           schema:
@@ -160,7 +160,7 @@ paths:
       - $ref: '#/parameters/AgentID'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '409':
           description: Agent does not exist or is not logged
           schema:
@@ -177,7 +177,7 @@ paths:
       - $ref: '#/parameters/AgentNumber'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '409':
           description: Agent does not exist or is not logged
           schema:
@@ -194,7 +194,7 @@ paths:
       - $ref: '#/parameters/tenantuuid'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '400':
           description: The token has no user; or wrong tenant; or the user has no agent
           schema:
@@ -222,7 +222,7 @@ paths:
           $ref: '#/definitions/AgentPauseReason'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '404':
           description: Agent does not exist
           schema:
@@ -249,7 +249,7 @@ paths:
           $ref: '#/definitions/AgentPauseReason'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '400':
           description: The token has no user; or wrong tenant; or the user has no agent
           schema:
@@ -271,7 +271,7 @@ paths:
       - $ref: '#/parameters/AgentNumber'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '404':
           description: Agent does not exist
           schema:
@@ -292,7 +292,7 @@ paths:
       - $ref: '#/parameters/tenantuuid'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '400':
           description: The token has no user; or wrong tenant; or the user has no agent
           schema:
@@ -320,7 +320,7 @@ paths:
           $ref: '#/definitions/Queue'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '400':
           description: The agent and the queue are not in the same tenant
           schema:
@@ -351,7 +351,7 @@ paths:
           $ref: '#/definitions/Queue'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '404':
           description: Agent or queue does not exist
           schema:
@@ -373,7 +373,7 @@ paths:
       - $ref: '#/parameters/QueueID'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '404':
           description: Agent or queue does not exist
           schema:
@@ -391,7 +391,7 @@ paths:
       - $ref: '#/parameters/QueueID'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '400':
           description: The token has no user; or wrong tenant; or the user has no agent
           schema:
@@ -413,7 +413,7 @@ paths:
       - $ref: '#/parameters/QueueID'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '404':
           description: Agent or queue does not exist
           schema:
@@ -431,7 +431,7 @@ paths:
       - $ref: '#/parameters/QueueID'
       responses:
         '204':
-          description: The operation was performed succesfully
+          description: The operation was performed successfully
         '400':
           description: The token has no user; or wrong tenant; or the user has no agent
           schema:

--- a/wazo_agentd/plugins/agent/api.yml
+++ b/wazo_agentd/plugins/agent/api.yml
@@ -408,6 +408,28 @@ paths:
           description: Agent or queue does not exist
           schema:
             $ref: '#/definitions/Error'
+  /agents/{agent_id}/queues/{queue_id}/logoff:
+    put:
+      summary: Logoff agent from queue
+      description: '**Required ACL:** `agentd.agents.{agent_id}.queues.{queue_id}.logoff.update`'
+      operationId: logoff_agent_from_queue
+      tags:
+      - agent
+      parameters:
+      - $ref: '#/parameters/tenantuuid'
+      - $ref: '#/parameters/AgentID'
+      - name: queue_id
+        type: integer
+        in: path
+        required: true
+        description: Queue's ID
+      responses:
+        '204':
+          description: The operation was performed succesfully
+        '404':
+          description: Agent or queue does not exist
+          schema:
+            $ref: '#/definitions/Error'
   /users/me/agents/queues/{queue_id}/logoff:
     put:
       summary: Logoff user agent from queue

--- a/wazo_agentd/plugins/agent/http.py
+++ b/wazo_agentd/plugins/agent/http.py
@@ -209,6 +209,14 @@ class QueueLoginUserAgent(_BaseAgentResource):
         return '', 204
 
 
+class QueueLogoffAgentById(_BaseAgentResource):
+    @required_acl('agentd.agents.{agent_id}.queues.{queue_id}.logoff.update')
+    def put(self, agent_id: int, queue_id: int):
+        tenant_uuids = self._build_tenant_list({'recurse': True})
+        self.service_proxy.logoff_agent_from_queue(agent_id, queue_id, tenant_uuids)
+        return '', 204
+
+
 class QueueLogoffUserAgent(_BaseAgentResource):
     @required_acl('agentd.users.me.agents.queues.{queue_id}.logoff.update')
     def put(self, queue_id: int):

--- a/wazo_agentd/plugins/agent/http.py
+++ b/wazo_agentd/plugins/agent/http.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -189,6 +189,14 @@ class UnpauseUserAgent(_BaseAgentResource):
         tenant_uuids = self._build_tenant_list({'recurse': True})
         user_uuid = token.user_uuid
         self.service_proxy.unpause_user_agent(user_uuid, tenant_uuids=tenant_uuids)
+        return '', 204
+
+
+class QueueLoginAgentById(_BaseAgentResource):
+    @required_acl('agentd.agents.{agent_id}.queues.{queue_id}.login.update')
+    def put(self, agent_id: int, queue_id: int):
+        tenant_uuids = self._build_tenant_list({'recurse': True})
+        self.service_proxy.login_agent_to_queue(agent_id, queue_id, tenant_uuids)
         return '', 204
 
 

--- a/wazo_agentd/plugins/agent/plugin.py
+++ b/wazo_agentd/plugins/agent/plugin.py
@@ -15,6 +15,7 @@ from .http import (
     PauseUserAgent,
     QueueLoginAgentById,
     QueueLoginUserAgent,
+    QueueLogoffAgentById,
     QueueLogoffUserAgent,
     RemoveAgentFromQueue,
     UnpauseAgentByNumber,
@@ -125,6 +126,11 @@ class Plugin:
         api.add_resource(
             QueueLoginUserAgent,
             '/users/me/agents/queues/<int:queue_id>/login',
+            resource_class_args=[service_proxy],
+        )
+        api.add_resource(
+            QueueLogoffAgentById,
+            '/agents/<int:agent_id>/queues/<int:queue_id>/logoff',
             resource_class_args=[service_proxy],
         )
         api.add_resource(

--- a/wazo_agentd/plugins/agent/plugin.py
+++ b/wazo_agentd/plugins/agent/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .http import (
@@ -13,6 +13,7 @@ from .http import (
     LogoffUserAgent,
     PauseAgentByNumber,
     PauseUserAgent,
+    QueueLoginAgentById,
     QueueLoginUserAgent,
     QueueLogoffUserAgent,
     RemoveAgentFromQueue,
@@ -114,6 +115,11 @@ class Plugin:
         api.add_resource(
             UnpauseAgentByNumber,
             '/agents/by-number/<agent_number>/unpause',
+            resource_class_args=[service_proxy],
+        )
+        api.add_resource(
+            QueueLoginAgentById,
+            '/agents/<int:agent_id>/queues/<int:queue_id>/login',
             resource_class_args=[service_proxy],
         )
         api.add_resource(

--- a/wazo_agentd/service/handler/membership.py
+++ b/wazo_agentd/service/handler/membership.py
@@ -83,6 +83,18 @@ class MembershipHandler:
         self._queue_manager.login_to_queue(agent, queue)
 
     @debug.trace_duration
+    def handle_agent_queue_logoff(self, agent_id, queue_id, tenant_uuids=None):
+        logger.info(
+            'Executing queue logoff command (agent ID %s, queue ID %s)',
+            agent_id,
+            queue_id,
+        )
+        with db_utils.session_scope():
+            agent = self._agent_dao.get_agent(agent_id, tenant_uuids=tenant_uuids)
+            queue = self._queue_dao.get_queue(queue_id, tenant_uuids=tenant_uuids)
+        self._queue_manager.logoff_from_queue(agent, queue)
+
+    @debug.trace_duration
     def handle_user_agent_queue_logoff(self, user_uuid, queue_id, tenant_uuids=None):
         logger.info(
             'Executing queue logoff command (agent of user %s, queue ID %s)',

--- a/wazo_agentd/service/handler/membership.py
+++ b/wazo_agentd/service/handler/membership.py
@@ -59,6 +59,18 @@ class MembershipHandler:
         self._remove_member_manager.remove_agent_from_queue(agent, queue)
 
     @debug.trace_duration
+    def handle_agent_queue_login(self, agent_id, queue_id, tenant_uuids=None):
+        logger.info(
+            'Executing queue login command (agent ID %s, queue ID %s)',
+            agent_id,
+            queue_id,
+        )
+        with db_utils.session_scope():
+            agent = self._agent_dao.get_agent(agent_id, tenant_uuids=tenant_uuids)
+            queue = self._queue_dao.get_queue(queue_id, tenant_uuids=tenant_uuids)
+        self._queue_manager.login_to_queue(agent, queue)
+
+    @debug.trace_duration
     def handle_user_agent_queue_login(self, user_uuid, queue_id, tenant_uuids=None):
         logger.info(
             'Executing queue login command (agent of user %s, queue ID %s)',

--- a/wazo_agentd/service/proxy.py
+++ b/wazo_agentd/service/proxy.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -53,6 +53,12 @@ class ServiceProxy:
         with self._lock:
             self.membership_handler.handle_remove_from_queue(
                 agent_id, queue_id, tenant_uuids=tenant_uuids
+            )
+
+    def login_agent_to_queue(self, agent_id, queue_id, tenant_uuids=None):
+        with self._lock:
+            self.membership_handler.handle_agent_queue_login(
+                agent_id, queue_id, tenant_uuids
             )
 
     def login_user_agent_to_queue(self, user_uuid, queue_id, tenant_uuids=None):

--- a/wazo_agentd/service/proxy.py
+++ b/wazo_agentd/service/proxy.py
@@ -67,6 +67,12 @@ class ServiceProxy:
                 user_uuid, queue_id, tenant_uuids
             )
 
+    def logoff_agent_from_queue(self, agent_id, queue_id, tenant_uuids=None):
+        with self._lock:
+            self.membership_handler.handle_agent_queue_logoff(
+                agent_id, queue_id, tenant_uuids
+            )
+
     def logoff_user_agent_from_queue(self, user_uuid, queue_id, tenant_uuids=None):
         with self._lock:
             self.membership_handler.handle_user_agent_queue_logoff(


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-agentd-client/pull/34

- **Add admin endpoint for per-queue agent login**
- **Add admin endpoint for per-queue agent logoff**
- **Update CHANGELOG for 26.05 per-queue admin endpoints**
- **Extract QueueID as reusable OpenAPI parameter**
- **Normalize OpenAPI tags to plural form**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new queue membership state transitions via admin endpoints and touches multi-tenant/ACL-guarded service paths, so regressions could affect queue login state and events. Changes are localized and covered by new integration tests.
> 
> **Overview**
> Adds **admin per-queue agent login/logoff** APIs: `PUT /agents/{agent_id}/queues/{queue_id}/login` and `PUT /agents/{agent_id}/queues/{queue_id}/logoff`, including new ACLs and route/resources wired through `plugins/agent/http.py`, `plugin.py`, `service/proxy.py`, and `service/handler/membership.py`.
> 
> Updates the OpenAPI spec to document the new endpoints, reuse a new `QueueID` parameter, normalize tags to plural (`agents`/`users`), and correct several “succesfully” typos; the changelog is bumped with a `26.05` entry.
> 
> Expands integration coverage for the admin queue login/logoff flows (success + unknown agent/queue + not-logged) and adjusts test DB helper queue-member association to fall back to `Agent/{number}` when no PJSIP line is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c785efe07ee590f56b31cb251b9b1be39a658cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->