### PR TITLE
[TASK-252] add all_queues flag to relog all queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   * PUT `/agents/{agent_id}/queues/{queue_id}/login`
   * PUT `/agents/{agent_id}/queues/{queue_id}/logoff`
 
+* Added `all_queues` query parameter to force relogging an agent into all of
+  its assigned queues, restoring membership for queues the agent was previously
+  logged off from individually.
+
+  * POST `/agents/relog`
+
 ## 25.17
 
 * Added endpoints for user agents to login/logoff of its queues

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -651,12 +651,28 @@ class TestAgents(BaseIntegrationTest):
             assert status.queues[0]['logged'] is True
             assert status.queues[1]['logged'] is False
 
+            accumulator = self.bus.accumulator(
+                headers={'name': 'user_agent_queue_logged_in'}
+            )
+
             self.agentd.agents.relog_all_agents(all_queues=True)
 
             status = self.agentd.agents.get_agent_status(agent['id'])
             assert status.logged is True
             assert status.queues[0]['logged'] is True
             assert status.queues[1]['logged'] is True
+
+            accumulator.until_assert_that_accumulate(
+                has_items(
+                    has_entries(
+                        {f'user_uuid:{user_line_extension["user_uuid"]}': True},
+                        data=has_entries(
+                            agent_id=agent['id'],
+                            queue_id=queue_2['id'],
+                        ),
+                    ),
+                )
+            )
 
     @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent()

--- a/integration_tests/suite/test_agents.py
+++ b/integration_tests/suite/test_agents.py
@@ -626,6 +626,67 @@ class TestAgents(BaseIntegrationTest):
             assert status.queues[1]['logged'] is True
 
     @fixtures.user_line_extension(exten='1001', context='default')
+    @fixtures.agent()
+    @fixtures.queue()
+    @fixtures.queue()
+    def test_relog_all_agents_all_queues_flag(
+        self, user_line_extension, agent, queue_1, queue_2
+    ):
+        with associations.user_agent(
+            self.database, user_line_extension['user_id'], agent['id']
+        ):
+            with self.database.queries() as db:
+                db.associate_queue_agent(queue_1['id'], agent['id'])
+                db.associate_queue_agent(queue_2['id'], agent['id'])
+                db.insert_agent_membership_status(queue_1['id'], agent['id'])
+
+            self.agentd.agents.login_agent(
+                agent['id'],
+                user_line_extension['exten'],
+                user_line_extension['context'],
+            )
+
+            status = self.agentd.agents.get_agent_status(agent['id'])
+            assert status.logged is True
+            assert status.queues[0]['logged'] is True
+            assert status.queues[1]['logged'] is False
+
+            self.agentd.agents.relog_all_agents(all_queues=True)
+
+            status = self.agentd.agents.get_agent_status(agent['id'])
+            assert status.logged is True
+            assert status.queues[0]['logged'] is True
+            assert status.queues[1]['logged'] is True
+
+    @fixtures.user_line_extension(exten='1001', context='default')
+    @fixtures.agent()
+    @fixtures.queue()
+    @fixtures.queue()
+    def test_relog_all_agents_preserves_queue_status_by_default(
+        self, user_line_extension, agent, queue_1, queue_2
+    ):
+        with associations.user_agent(
+            self.database, user_line_extension['user_id'], agent['id']
+        ):
+            with self.database.queries() as db:
+                db.associate_queue_agent(queue_1['id'], agent['id'])
+                db.associate_queue_agent(queue_2['id'], agent['id'])
+                db.insert_agent_membership_status(queue_1['id'], agent['id'])
+
+            self.agentd.agents.login_agent(
+                agent['id'],
+                user_line_extension['exten'],
+                user_line_extension['context'],
+            )
+
+            self.agentd.agents.relog_all_agents()
+
+            status = self.agentd.agents.get_agent_status(agent['id'])
+            assert status.logged is True
+            assert status.queues[0]['logged'] is True
+            assert status.queues[1]['logged'] is False
+
+    @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent(number='1234')
     @fixtures.queue(name='Queue1')
     def test_adding_queue_to_logged_off_agent_enables_it_for_next_login(

--- a/wazo_agentd/main.py
+++ b/wazo_agentd/main.py
@@ -165,7 +165,12 @@ def _run(config):
         agent_status_dao, user_dao, agent_dao, bus_publisher
     )
     relog_manager = RelogManager(
-        login_action, logoff_action, agent_dao, agent_status_dao
+        login_action,
+        logoff_action,
+        agent_dao,
+        agent_status_dao,
+        user_dao,
+        bus_publisher,
     )
     remove_member_manager = RemoveMemberManager(
         remove_from_queue_action, amid_client, queue_member_dao

--- a/wazo_agentd/plugins/agents/api.yml
+++ b/wazo_agentd/plugins/agents/api.yml
@@ -38,6 +38,14 @@ paths:
       - agents
       parameters:
       - $ref: '#/parameters/tenantuuid'
+      - name: all_queues
+        in: query
+        type: boolean
+        description: If true, relog each agent into all of its assigned queues,
+          restoring membership for queues from which the agent was previously
+          logged off individually.
+        default: false
+        required: false
       responses:
         '204':
           description: The operation was performed succesfully

--- a/wazo_agentd/plugins/agents/http.py
+++ b/wazo_agentd/plugins/agents/http.py
@@ -33,5 +33,6 @@ class RelogAgents(_BaseAgentResource):
     def post(self):
         params = self.parse_params()
         tenant_uuids = self._build_tenant_list(params)
-        self.service_proxy.relog_all(tenant_uuids=tenant_uuids)
+        all_queues = params.get('all_queues', 'false').lower() == 'true'
+        self.service_proxy.relog_all(tenant_uuids=tenant_uuids, all_queues=all_queues)
         return '', 204

--- a/wazo_agentd/service/handler/relog.py
+++ b/wazo_agentd/service/handler/relog.py
@@ -13,6 +13,8 @@ class RelogHandler:
         self._relog_manager = relog_manager
 
     @debug.trace_duration
-    def handle_relog_all(self, tenant_uuids=None):
-        logger.info('Executing relog all command')
-        self._relog_manager.relog_all_agents(tenant_uuids=tenant_uuids)
+    def handle_relog_all(self, tenant_uuids=None, all_queues=False):
+        logger.info('Executing relog all command (all_queues=%s)', all_queues)
+        self._relog_manager.relog_all_agents(
+            tenant_uuids=tenant_uuids, all_queues=all_queues
+        )

--- a/wazo_agentd/service/handler/tests/test_relog.py
+++ b/wazo_agentd/service/handler/tests/test_relog.py
@@ -19,5 +19,12 @@ class TestRelogHandler(unittest.TestCase):
         self.relog_handler.handle_relog_all(tenant_uuids=self.tenants)
 
         self.relog_manager.relog_all_agents.assert_called_once_with(
-            tenant_uuids=self.tenants
+            tenant_uuids=self.tenants, all_queues=False
+        )
+
+    def test_handle_relog_all_all_queues(self):
+        self.relog_handler.handle_relog_all(tenant_uuids=self.tenants, all_queues=True)
+
+        self.relog_manager.relog_all_agents.assert_called_once_with(
+            tenant_uuids=self.tenants, all_queues=True
         )

--- a/wazo_agentd/service/manager/relog.py
+++ b/wazo_agentd/service/manager/relog.py
@@ -1,19 +1,30 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 
+from wazo_bus.resources.user_agent.event import UserAgentQueueLoggedInEvent
 from xivo_dao.helpers import db_utils
 
 logger = logging.getLogger(__name__)
 
 
 class RelogManager:
-    def __init__(self, login_action, logoff_action, agent_dao, agent_status_dao):
+    def __init__(
+        self,
+        login_action,
+        logoff_action,
+        agent_dao,
+        agent_status_dao,
+        user_dao,
+        bus_publisher,
+    ):
         self._login_action = login_action
         self._logoff_action = logoff_action
         self._agent_dao = agent_dao
         self._agent_status_dao = agent_status_dao
+        self._user_dao = user_dao
+        self._bus_publisher = bus_publisher
 
     def relog_all_agents(self, tenant_uuids=None, all_queues=False):
         agent_statuses = self._get_agent_statuses(tenant_uuids=tenant_uuids)
@@ -36,11 +47,29 @@ class RelogManager:
 
     def _relog_agent(self, agent_status, all_queues=False):
         self._logoff_action.logoff_agent(agent_status)
+        newly_logged_queues = []
         with db_utils.session_scope():
             agent = self._agent_dao.get_agent(agent_status.agent_id)
             if all_queues:
+                previously_logged_ids = {
+                    q.id for q in self._agent_dao.list_agent_enabled_queues(agent.id)
+                }
                 self._agent_status_dao.remove_agent_from_all_queues(agent.id)
                 self._agent_status_dao.add_agent_to_queues(agent.id, agent.queues)
+                newly_logged_queues = [
+                    q for q in agent.queues if q.id not in previously_logged_ids
+                ]
         self._login_action.login_agent(
             agent, agent_status.extension, agent_status.context
         )
+        if newly_logged_queues:
+            self._publish_queue_logged_in_events(agent, newly_logged_queues)
+
+    def _publish_queue_logged_in_events(self, agent, queues):
+        with db_utils.session_scope():
+            user_uuids = [u.uuid for u in self._user_dao.find_all_by_agent_id(agent.id)]
+        for queue in queues:
+            event = UserAgentQueueLoggedInEvent(
+                agent.id, queue.id, agent.tenant_uuid, user_uuids
+            )
+            self._bus_publisher.publish(event)

--- a/wazo_agentd/service/manager/relog.py
+++ b/wazo_agentd/service/manager/relog.py
@@ -15,11 +15,11 @@ class RelogManager:
         self._agent_dao = agent_dao
         self._agent_status_dao = agent_status_dao
 
-    def relog_all_agents(self, tenant_uuids=None):
+    def relog_all_agents(self, tenant_uuids=None, all_queues=False):
         agent_statuses = self._get_agent_statuses(tenant_uuids=tenant_uuids)
         for agent_status in agent_statuses:
             try:
-                self._relog_agent(agent_status)
+                self._relog_agent(agent_status, all_queues=all_queues)
             except Exception:
                 logger.warning(
                     'Could not relog agent %s', agent_status.agent_id, exc_info=True
@@ -34,10 +34,13 @@ class RelogManager:
                 self._agent_status_dao.get_status(agent_id) for agent_id in agent_ids
             ]
 
-    def _relog_agent(self, agent_status):
+    def _relog_agent(self, agent_status, all_queues=False):
         self._logoff_action.logoff_agent(agent_status)
         with db_utils.session_scope():
             agent = self._agent_dao.get_agent(agent_status.agent_id)
+            if all_queues:
+                self._agent_status_dao.remove_agent_from_all_queues(agent.id)
+                self._agent_status_dao.add_agent_to_queues(agent.id, agent.queues)
         self._login_action.login_agent(
             agent, agent_status.extension, agent_status.context
         )

--- a/wazo_agentd/service/manager/tests/test_relog.py
+++ b/wazo_agentd/service/manager/tests/test_relog.py
@@ -22,6 +22,7 @@ class TestRelogManager(unittest.TestCase):
     def test_relog_all_agents(self):
         agent_id = 42
         agent = Mock()
+        agent.id = agent_id
         agent_status = Mock()
         agent_status.agent_id = agent_id
 
@@ -34,6 +35,33 @@ class TestRelogManager(unittest.TestCase):
         self.agent_status_dao.get_status.assert_called_once_with(agent_id)
         self.logoff_action.logoff_agent.assert_called_once_with(agent_status)
         self.agent_dao.get_agent.assert_called_once_with(agent_id)
+        self.agent_status_dao.remove_agent_from_all_queues.assert_not_called()
+        self.agent_status_dao.add_agent_to_queues.assert_not_called()
+        self.login_action.login_agent.assert_called_once_with(
+            agent, agent_status.extension, agent_status.context
+        )
+
+    def test_relog_all_agents_all_queues(self):
+        agent_id = 42
+        agent = Mock()
+        agent.id = agent_id
+        agent.queues = [Mock(), Mock()]
+        agent_status = Mock()
+        agent_status.agent_id = agent_id
+
+        self.agent_dao.get_agent.return_value = agent
+        self.agent_status_dao.get_logged_agent_ids.return_value = [agent_id]
+        self.agent_status_dao.get_status.return_value = agent_status
+
+        self.relog_manager.relog_all_agents(all_queues=True)
+
+        self.logoff_action.logoff_agent.assert_called_once_with(agent_status)
+        self.agent_status_dao.remove_agent_from_all_queues.assert_called_once_with(
+            agent_id
+        )
+        self.agent_status_dao.add_agent_to_queues.assert_called_once_with(
+            agent_id, agent.queues
+        )
         self.login_action.login_agent.assert_called_once_with(
             agent, agent_status.extension, agent_status.context
         )

--- a/wazo_agentd/service/manager/tests/test_relog.py
+++ b/wazo_agentd/service/manager/tests/test_relog.py
@@ -1,8 +1,10 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 from unittest.mock import Mock
+
+from wazo_bus.resources.user_agent.event import UserAgentQueueLoggedInEvent
 
 from wazo_agentd.service.action.login import LoginAction
 from wazo_agentd.service.action.logoff import LogoffAction
@@ -15,8 +17,15 @@ class TestRelogManager(unittest.TestCase):
         self.logoff_action = Mock(LogoffAction)
         self.agent_status_dao = Mock()
         self.agent_dao = Mock()
+        self.user_dao = Mock()
+        self.bus_publisher = Mock()
         self.relog_manager = RelogManager(
-            self.login_action, self.logoff_action, self.agent_dao, self.agent_status_dao
+            self.login_action,
+            self.logoff_action,
+            self.agent_dao,
+            self.agent_status_dao,
+            self.user_dao,
+            self.bus_publisher,
         )
 
     def test_relog_all_agents(self):
@@ -40,18 +49,26 @@ class TestRelogManager(unittest.TestCase):
         self.login_action.login_agent.assert_called_once_with(
             agent, agent_status.extension, agent_status.context
         )
+        self.bus_publisher.publish.assert_not_called()
 
-    def test_relog_all_agents_all_queues(self):
+    def test_relog_all_agents_all_queues_emits_event_for_newly_logged_queue(self):
         agent_id = 42
-        agent = Mock()
-        agent.id = agent_id
-        agent.queues = [Mock(), Mock()]
-        agent_status = Mock()
-        agent_status.agent_id = agent_id
+        tenant_uuid = 'tenant-uuid'
+        queue_already_logged = Mock(id=10)
+        queue_newly_logged = Mock(id=11)
+        agent = Mock(
+            id=agent_id,
+            tenant_uuid=tenant_uuid,
+            queues=[queue_already_logged, queue_newly_logged],
+        )
+        agent_status = Mock(agent_id=agent_id)
+        user = Mock(uuid='user-uuid-1')
 
         self.agent_dao.get_agent.return_value = agent
+        self.agent_dao.list_agent_enabled_queues.return_value = [queue_already_logged]
         self.agent_status_dao.get_logged_agent_ids.return_value = [agent_id]
         self.agent_status_dao.get_status.return_value = agent_status
+        self.user_dao.find_all_by_agent_id.return_value = [user]
 
         self.relog_manager.relog_all_agents(all_queues=True)
 
@@ -65,3 +82,22 @@ class TestRelogManager(unittest.TestCase):
         self.login_action.login_agent.assert_called_once_with(
             agent, agent_status.extension, agent_status.context
         )
+        expected_event = UserAgentQueueLoggedInEvent(
+            agent_id, queue_newly_logged.id, tenant_uuid, ['user-uuid-1']
+        )
+        self.bus_publisher.publish.assert_called_once_with(expected_event)
+
+    def test_relog_all_agents_all_queues_no_event_when_nothing_changed(self):
+        agent_id = 42
+        queue = Mock(id=10)
+        agent = Mock(id=agent_id, tenant_uuid='tenant-uuid', queues=[queue])
+        agent_status = Mock(agent_id=agent_id)
+
+        self.agent_dao.get_agent.return_value = agent
+        self.agent_dao.list_agent_enabled_queues.return_value = [queue]
+        self.agent_status_dao.get_logged_agent_ids.return_value = [agent_id]
+        self.agent_status_dao.get_status.return_value = agent_status
+
+        self.relog_manager.relog_all_agents(all_queues=True)
+
+        self.bus_publisher.publish.assert_not_called()

--- a/wazo_agentd/service/proxy.py
+++ b/wazo_agentd/service/proxy.py
@@ -129,9 +129,11 @@ class ServiceProxy:
         with self._lock:
             self.logoff_handler.handle_logoff_all(tenant_uuids=tenant_uuids)
 
-    def relog_all(self, tenant_uuids=None):
+    def relog_all(self, tenant_uuids=None, all_queues=False):
         with self._lock:
-            self.relog_handler.handle_relog_all(tenant_uuids=tenant_uuids)
+            self.relog_handler.handle_relog_all(
+                tenant_uuids=tenant_uuids, all_queues=all_queues
+            )
 
     def pause_agent_by_number(self, agent_number, reason, tenant_uuids=None):
         with self._lock:

--- a/wazo_agentd/service/tests/test_proxy.py
+++ b/wazo_agentd/service/tests/test_proxy.py
@@ -127,7 +127,14 @@ class TestServiceProxy(unittest.TestCase):
         self.proxy.relog_all(tenant_uuids=self.tenants)
 
         self.relog_handler.handle_relog_all.assert_called_once_with(
-            tenant_uuids=self.tenants
+            tenant_uuids=self.tenants, all_queues=False
+        )
+
+    def test_relog_all_with_all_queues(self):
+        self.proxy.relog_all(tenant_uuids=self.tenants, all_queues=True)
+
+        self.relog_handler.handle_relog_all.assert_called_once_with(
+            tenant_uuids=self.tenants, all_queues=True
         )
 
     def test_pause_agent_by_number(self):


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-agentd-client/pull/35


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an optional behavior that rewrites per-agent queue membership state during relog and emits new bus events, which could affect agent/queue state consistency if misused or if DAO assumptions differ across deployments.
> 
> **Overview**
> Adds an `all_queues` query parameter to `POST /agents/relog` to optionally *restore agents into all assigned queues* when relogging, rather than preserving per-queue logged-off state.
> 
> When `all_queues=true`, `RelogManager` now resets and repopulates queue membership status from the agent’s assigned queues and publishes `UserAgentQueueLoggedInEvent` events for any queues that become newly logged-in as a result.
> 
> Updates wiring (`main.py`), handler/proxy/http layers, API spec, changelog, and adds unit + integration tests to cover default vs `all_queues` behavior and event emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ba2a023b33c59ffb659ee783f5962dc20b0644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->