### PR TITLE
docker: pin rabbitmq to 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "5432"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - '5672'
     volumes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes the integration-test Docker Compose to use a pinned `rabbitmq:3` image, reducing variability without affecting application code paths.
> 
> **Overview**
> Pins the integration test `rabbitmq` service image from `rabbitmq` (latest) to `rabbitmq:3` in `integration_tests/assets/docker-compose.yml` to make the test environment deterministic and avoid unexpected breakages from upstream image updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544127efa0a272bf602d62c5fcdfd1260b6eb18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->