### PR TITLE
ITEM-424-fix-agent-deletion-cleanup

### DIFF
--- a/integration_tests/suite/helpers/amid.py
+++ b/integration_tests/suite/helpers/amid.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -25,6 +25,14 @@ class AmidClient:
     def set_queueremove(self):
         url = self.url('_set_response_action')
         body = {'response': 'QueueRemove', 'content': [{'Response': 'Success'}]}
+        requests.post(url, json=body)
+
+    def set_queueremove_error(self, message):
+        url = self.url('_set_response_action')
+        body = {
+            'response': 'QueueRemove',
+            'content': [{'Response': 'Error', 'Message': message}],
+        }
         requests.post(url, json=body)
 
     def set_userevent(self):

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_test_helpers import bus as bus_helper
@@ -28,9 +28,12 @@ class BusClient(bus_helper.BusClient):
             headers={'name': 'QueueMemberPause'},
         )
 
-    def send_agent_deleted_event(self, agent_id):
+    def send_agent_deleted_event(self, agent_id, tenant_uuid):
         self.publish(
-            {'data': {'id': agent_id}, 'name': 'agent_deleted'},
+            {
+                'data': {'id': agent_id, 'tenant_uuid': tenant_uuid},
+                'name': 'agent_deleted',
+            },
             headers={'name': 'agent_deleted'},
             routing_key='config.agent.deleted',
         )

--- a/integration_tests/suite/test_event_handler.py
+++ b/integration_tests/suite/test_event_handler.py
@@ -60,6 +60,54 @@ class TestEventHandler(BaseIntegrationTest):
         until.assert_(check_agent_status, tries=10)
 
     @fixtures.user_line_extension(exten='1001', context='default')
+    @fixtures.agent(number='1001')
+    @fixtures.agent(number='1002')
+    @fixtures.queue()
+    def test_login_on_same_extension_after_agent_deleted(
+        self, user_line_extension, deleted_agent, agent, queue
+    ):
+        # Non-regression test: a logged agent whose phone is unreachable is
+        # deleted; its statuses must be cleaned up so another agent can log in
+        # on the same extension
+        with self.database.queries() as queries:
+            queries.associate_queue_agent(queue['id'], deleted_agent['id'])
+            queries.insert_agent_membership_status(queue['id'], deleted_agent['id'])
+            with queries.inserter() as inserter:
+                inserter.add_agent_login_status(
+                    agent_id=deleted_agent['id'],
+                    agent_number=deleted_agent['number'],
+                    extension=user_line_extension['exten'],
+                    context=user_line_extension['context'],
+                )
+
+        self.amid.set_queueremove_error('Unable to remove interface: Not there')
+        self.addCleanup(self.amid.set_queueremove)
+
+        with self.database.queries() as queries:
+            queries.delete_only_agent(deleted_agent['id'])
+        self.bus.send_agent_deleted_event(deleted_agent['id'], TENANT_UUID)
+
+        def check_deleted_agent_cleanup():
+            with self.database.queries() as queries:
+                status = queries.get_agent_login_status_by_id(deleted_agent['id'])
+                assert_that(status, is_(None))
+                membership = queries.get_agent_membership_status(
+                    queue['id'], deleted_agent['id']
+                )
+                assert_that(membership, is_(None))
+
+        until.assert_(check_deleted_agent_cleanup, tries=10)
+
+        self.agentd.agents.login_agent(
+            agent['id'],
+            user_line_extension['exten'],
+            user_line_extension['context'],
+        )
+
+        status = self.agentd.agents.get_agent_status(agent['id'])
+        assert_that(status.logged, is_(True))
+
+    @fixtures.user_line_extension(exten='1001', context='default')
     @fixtures.agent(number='1234')
     @fixtures.queue()
     def test_on_queue_member_agent_associated(self, user_line_extension, agent, queue):

--- a/integration_tests/suite/test_event_handler.py
+++ b/integration_tests/suite/test_event_handler.py
@@ -10,6 +10,7 @@ from wazo_test_helpers import until
 
 from .helpers import fixtures
 from .helpers.base import BaseIntegrationTest
+from .helpers.database import TENANT_UUID
 
 
 class TestEventHandler(BaseIntegrationTest):
@@ -55,7 +56,7 @@ class TestEventHandler(BaseIntegrationTest):
 
         with self.database.queries() as queries:
             queries.delete_only_agent(agent['id'])
-        self.bus.send_agent_deleted_event(agent['id'])
+        self.bus.send_agent_deleted_event(agent['id'], TENANT_UUID)
         until.assert_(check_agent_status, tries=10)
 
     @fixtures.user_line_extension(exten='1001', context='default')

--- a/wazo_agentd/main.py
+++ b/wazo_agentd/main.py
@@ -125,7 +125,6 @@ def _run(config):
         pause_manager,
         agent_status_dao,
         user_dao,
-        agent_dao,
         bus_publisher,
     )
     queue_manager = QueueManager(

--- a/wazo_agentd/service/action/logoff.py
+++ b/wazo_agentd/service/action/logoff.py
@@ -20,7 +20,6 @@ class LogoffAction:
         pause_manager,
         agent_status_dao,
         user_dao,
-        agent_dao,
         bus_publisher,
     ):
         self._amid_client = amid_client
@@ -29,7 +28,6 @@ class LogoffAction:
         self._pause_manager = pause_manager
         self._agent_status_dao = agent_status_dao
         self._user_dao = user_dao
-        self._agent_dao = agent_dao
         self._bus_publisher = bus_publisher
 
     def logoff_agent(self, agent_status):
@@ -112,21 +110,11 @@ class LogoffAction:
     def _send_bus_status_update(self, agent_status):
         agent_id = agent_status.agent_id
         with db_utils.session_scope():
-            try:
-                tenant_uuid = self._agent_dao.agent_with_id(agent_id).tenant_uuid
-            except LookupError:
-                # TODO(ITEM-424): temporary workaround. The agent no longer
-                # exists (logoff triggered by its deletion), so the status
-                # update event is skipped. The right fix is to extract
-                # tenant_uuid from the agent_deleted event and pass it down
-                # here so the event can still be published.
-                logger.debug(
-                    'agent %s not found, skipping status update event', agent_id
-                )
-                return
             users = [
                 user.uuid for user in self._user_dao.find_all_by_agent_id(agent_id)
             ]
             logger.debug('Found %s users.', len(users))
-            event = AgentStatusUpdatedEvent(agent_id, 'logged_out', tenant_uuid, users)
+            event = AgentStatusUpdatedEvent(
+                agent_id, 'logged_out', agent_status.tenant_uuid, users
+            )
             self._bus_publisher.publish(event)

--- a/wazo_agentd/service/action/logoff.py
+++ b/wazo_agentd/service/action/logoff.py
@@ -112,7 +112,18 @@ class LogoffAction:
     def _send_bus_status_update(self, agent_status):
         agent_id = agent_status.agent_id
         with db_utils.session_scope():
-            tenant_uuid = self._agent_dao.agent_with_id(agent_id).tenant_uuid
+            try:
+                tenant_uuid = self._agent_dao.agent_with_id(agent_id).tenant_uuid
+            except LookupError:
+                # TODO(ITEM-424): temporary workaround. The agent no longer
+                # exists (logoff triggered by its deletion), so the status
+                # update event is skipped. The right fix is to extract
+                # tenant_uuid from the agent_deleted event and pass it down
+                # here so the event can still be published.
+                logger.debug(
+                    'agent %s not found, skipping status update event', agent_id
+                )
+                return
             users = [
                 user.uuid for user in self._user_dao.find_all_by_agent_id(agent_id)
             ]

--- a/wazo_agentd/service/action/tests/test_logoff.py
+++ b/wazo_agentd/service/action/tests/test_logoff.py
@@ -20,7 +20,6 @@ class TestLogoffAction(unittest.TestCase):
         self.pause_manager = Mock()
         self.agent_status_dao = Mock()
         self.user_dao = Mock()
-        self.agent_dao = Mock()
         self.bus_publisher = Mock()
         self.logoff_action = LogoffAction(
             self.amid_client,
@@ -29,7 +28,6 @@ class TestLogoffAction(unittest.TestCase):
             self.pause_manager,
             self.agent_status_dao,
             self.user_dao,
-            self.agent_dao,
             self.bus_publisher,
         )
 
@@ -46,11 +44,11 @@ class TestLogoffAction(unittest.TestCase):
         agent_status.login_at = datetime.datetime.utcnow()
         agent_status.queues = [queue]
         tenant_uuid = '00000000-0000-4000-8000-000000001ebc'
+        agent_status.tenant_uuid = tenant_uuid
         self.user_dao.find_all_by_agent_id.return_value = [
             Mock(uuid='42'),
             Mock(uuid='43'),
         ]
-        self.agent_dao.agent_with_id.return_value = Mock(tenant_uuid=tenant_uuid)
         event = AgentStatusUpdatedEvent(10, 'logged_out', tenant_uuid, ['42', '43'])
         self.pause_manager.unpause_agent.side_effect = AmidProtocolError(
             Mock(json=Mock(return_value=[{'Message': 'Interface not found'}]))
@@ -103,11 +101,11 @@ class TestLogoffAction(unittest.TestCase):
         agent_status.login_at = datetime.datetime.utcnow()
         agent_status.queues = [queue]
         tenant_uuid = '00000000-0000-4000-8000-000000001ebc'
+        agent_status.tenant_uuid = tenant_uuid
         self.user_dao.find_all_by_agent_id.return_value = [
             Mock(uuid='42'),
             Mock(uuid='43'),
         ]
-        self.agent_dao.agent_with_id.return_value = Mock(tenant_uuid=tenant_uuid)
         event = AgentStatusUpdatedEvent(10, 'logged_out', tenant_uuid, ['42', '43'])
 
         self.logoff_action.logoff_agent(agent_status)
@@ -144,22 +142,6 @@ class TestLogoffAction(unittest.TestCase):
         )
         self.bus_publisher.publish.assert_called_once_with(event)
 
-    def test_logoff_agent_deleted_skips_status_update(self):
-        agent_id = 10
-        queue = Mock()
-        queue.name = 'q1'
-        agent_status = Mock(user_ids=[])
-        agent_status.agent_id = agent_id
-        agent_status.agent_number = '10'
-        agent_status.login_at = datetime.datetime.utcnow()
-        agent_status.queues = [queue]
-        self.agent_dao.agent_with_id.side_effect = LookupError('no agent found')
-
-        self.logoff_action.logoff_agent(agent_status)
-
-        self.agent_status_dao.log_off_agent.assert_called_once_with(agent_id)
-        self.bus_publisher.publish.assert_not_called()
-
     def test_logoff_agent_already_off_on_asterisk(self):
         agent_id = 10
         agent_number = '10'
@@ -176,7 +158,7 @@ class TestLogoffAction(unittest.TestCase):
             Mock(uuid='43'),
         ]
         tenant_uuid = '00000000-0000-4000-8000-000000001ebc'
-        self.agent_dao.agent_with_id.return_value = Mock(tenant_uuid=tenant_uuid)
+        agent_status.tenant_uuid = tenant_uuid
         event = AgentStatusUpdatedEvent(10, 'logged_out', tenant_uuid, ['42', '43'])
 
         response = Mock()

--- a/wazo_agentd/service/action/tests/test_logoff.py
+++ b/wazo_agentd/service/action/tests/test_logoff.py
@@ -144,6 +144,22 @@ class TestLogoffAction(unittest.TestCase):
         )
         self.bus_publisher.publish.assert_called_once_with(event)
 
+    def test_logoff_agent_deleted_skips_status_update(self):
+        agent_id = 10
+        queue = Mock()
+        queue.name = 'q1'
+        agent_status = Mock(user_ids=[])
+        agent_status.agent_id = agent_id
+        agent_status.agent_number = '10'
+        agent_status.login_at = datetime.datetime.utcnow()
+        agent_status.queues = [queue]
+        self.agent_dao.agent_with_id.side_effect = LookupError('no agent found')
+
+        self.logoff_action.logoff_agent(agent_status)
+
+        self.agent_status_dao.log_off_agent.assert_called_once_with(agent_id)
+        self.bus_publisher.publish.assert_not_called()
+
     def test_logoff_agent_already_off_on_asterisk(self):
         agent_id = 10
         agent_number = '10'

--- a/wazo_agentd/service/handler/on_agent.py
+++ b/wazo_agentd/service/handler/on_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -23,6 +23,6 @@ class OnAgentHandler:
         self._on_agent_updated_manager.on_agent_updated(agent)
 
     @debug.trace_duration
-    def handle_on_agent_deleted(self, agent_id):
+    def handle_on_agent_deleted(self, agent_id, tenant_uuid):
         logger.info('Executing on agent deleted command (ID %s)', agent_id)
-        self._on_agent_deleted_manager.on_agent_deleted(agent_id)
+        self._on_agent_deleted_manager.on_agent_deleted(agent_id, tenant_uuid)

--- a/wazo_agentd/service/manager/on_agent_deleted.py
+++ b/wazo_agentd/service/manager/on_agent_deleted.py
@@ -13,7 +13,7 @@ class OnAgentDeletedManager:
         self._logoff_action = logoff_action
         self._agent_status_dao = agent_status_dao
 
-    def on_agent_deleted(self, agent_id):
+    def on_agent_deleted(self, agent_id, tenant_uuid):
         with db_utils.session_scope():
             agent_status = (
                 self._agent_status_dao.get_agent_login_status_by_id_for_logoff(agent_id)
@@ -21,6 +21,9 @@ class OnAgentDeletedManager:
         if agent_status is None:
             logger.debug('agent %d has no active status requiring logoff', agent_id)
         else:
+            # The agent row is already deleted, so the status can only carry
+            # the tenant_uuid taken from the agent_deleted event
+            agent_status = agent_status._replace(tenant_uuid=tenant_uuid)
             self._logoff_action.logoff_agent(agent_status)
 
         with db_utils.session_scope():

--- a/wazo_agentd/service/manager/on_agent_deleted.py
+++ b/wazo_agentd/service/manager/on_agent_deleted.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -20,6 +20,8 @@ class OnAgentDeletedManager:
             )
         if agent_status is None:
             logger.debug('agent %d has no active status requiring logoff', agent_id)
-            return
+        else:
+            self._logoff_action.logoff_agent(agent_status)
 
-        self._logoff_action.logoff_agent(agent_status)
+        with db_utils.session_scope():
+            self._agent_status_dao.remove_agent_from_all_queues(agent_id)

--- a/wazo_agentd/service/manager/on_queue_agent_paused.py
+++ b/wazo_agentd/service/manager/on_queue_agent_paused.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -34,7 +34,16 @@ class OnQueueAgentPausedManager:
     def _send_bus_status_update(self, partial_event, agent_id):
         with db_utils.session_scope():
             logger.debug('Looking for users with agent id %s...', agent_id)
-            tenant_uuid = self._agent_dao.agent_with_id(agent_id).tenant_uuid
+            try:
+                tenant_uuid = self._agent_dao.agent_with_id(agent_id).tenant_uuid
+            except LookupError:
+                # Deleting a logged agent unpauses it in asterisk, so the
+                # resulting QueueMemberPause events reference an agent that no
+                # longer exists
+                logger.warning(
+                    'agent %s not found, ignoring pause status update', agent_id
+                )
+                return
             users = [
                 user.uuid for user in self._user_dao.find_all_by_agent_id(agent_id)
             ]

--- a/wazo_agentd/service/manager/tests/test_on_agent_deleted.py
+++ b/wazo_agentd/service/manager/tests/test_on_agent_deleted.py
@@ -1,0 +1,44 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest.mock import Mock
+
+from wazo_agentd.service.manager.on_agent_deleted import OnAgentDeletedManager
+
+
+class TestOnAgentDeletedManager(unittest.TestCase):
+    def setUp(self):
+        self.logoff_action = Mock()
+        self.agent_status_dao = Mock()
+        self.on_agent_deleted_manager = OnAgentDeletedManager(
+            self.logoff_action,
+            self.agent_status_dao,
+        )
+
+    def test_on_agent_deleted_logged_agent(self):
+        agent_id = 10
+        agent_status = Mock(agent_id=agent_id)
+        self.agent_status_dao.get_agent_login_status_by_id_for_logoff.return_value = (
+            agent_status
+        )
+
+        self.on_agent_deleted_manager.on_agent_deleted(agent_id)
+
+        self.logoff_action.logoff_agent.assert_called_once_with(agent_status)
+        self.agent_status_dao.remove_agent_from_all_queues.assert_called_once_with(
+            agent_id
+        )
+
+    def test_on_agent_deleted_agent_not_logged(self):
+        agent_id = 10
+        self.agent_status_dao.get_agent_login_status_by_id_for_logoff.return_value = (
+            None
+        )
+
+        self.on_agent_deleted_manager.on_agent_deleted(agent_id)
+
+        self.logoff_action.logoff_agent.assert_not_called()
+        self.agent_status_dao.remove_agent_from_all_queues.assert_called_once_with(
+            agent_id
+        )

--- a/wazo_agentd/service/manager/tests/test_on_agent_deleted.py
+++ b/wazo_agentd/service/manager/tests/test_on_agent_deleted.py
@@ -18,25 +18,30 @@ class TestOnAgentDeletedManager(unittest.TestCase):
 
     def test_on_agent_deleted_logged_agent(self):
         agent_id = 10
+        tenant_uuid = '00000000-0000-4000-8000-000000001ebc'
         agent_status = Mock(agent_id=agent_id)
         self.agent_status_dao.get_agent_login_status_by_id_for_logoff.return_value = (
             agent_status
         )
 
-        self.on_agent_deleted_manager.on_agent_deleted(agent_id)
+        self.on_agent_deleted_manager.on_agent_deleted(agent_id, tenant_uuid)
 
-        self.logoff_action.logoff_agent.assert_called_once_with(agent_status)
+        agent_status._replace.assert_called_once_with(tenant_uuid=tenant_uuid)
+        self.logoff_action.logoff_agent.assert_called_once_with(
+            agent_status._replace.return_value
+        )
         self.agent_status_dao.remove_agent_from_all_queues.assert_called_once_with(
             agent_id
         )
 
     def test_on_agent_deleted_agent_not_logged(self):
         agent_id = 10
+        tenant_uuid = '00000000-0000-4000-8000-000000001ebc'
         self.agent_status_dao.get_agent_login_status_by_id_for_logoff.return_value = (
             None
         )
 
-        self.on_agent_deleted_manager.on_agent_deleted(agent_id)
+        self.on_agent_deleted_manager.on_agent_deleted(agent_id, tenant_uuid)
 
         self.logoff_action.logoff_agent.assert_not_called()
         self.agent_status_dao.remove_agent_from_all_queues.assert_called_once_with(

--- a/wazo_agentd/service/manager/tests/test_on_agent_paused.py
+++ b/wazo_agentd/service/manager/tests/test_on_agent_paused.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -81,3 +81,13 @@ class TestOnQueueAgentPausedManager(unittest.TestCase):
             10, False, s.reason
         )
         self.bus_publisher.publish.assert_called_once_with(expected_event)
+
+    def test_on_queue_agent_unpaused_agent_deleted(self):
+        self.agent_dao.agent_with_id.side_effect = LookupError('no agent found')
+
+        self.manager.on_queue_agent_unpaused(10, s.number, s.reason, s.queue)
+
+        self.agent_status_dao.update_pause_status.assert_called_once_with(
+            10, False, s.reason
+        )
+        self.bus_publisher.publish.assert_not_called()

--- a/wazo_agentd/service/proxy.py
+++ b/wazo_agentd/service/proxy.py
@@ -187,7 +187,9 @@ class ServiceProxy:
 
     def on_agent_deleted(self, agent):
         with self._lock:
-            return self.on_agent_handler.handle_on_agent_deleted(agent['id'])
+            return self.on_agent_handler.handle_on_agent_deleted(
+                agent['id'], agent['tenant_uuid']
+            )
 
     def on_queue_updated(self, queue):
         with self._lock:

--- a/wazo_agentd/service/tests/test_proxy.py
+++ b/wazo_agentd/service/tests/test_proxy.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -35,7 +35,7 @@ class TestServiceProxy(unittest.TestCase):
         self.proxy.pause_handler = self.pause_handler
         self.proxy.relog_handler = self.relog_handler
         self.proxy.status_handler = self.status_handler
-        self.agent = {'id': s.agent_id}
+        self.agent = {'id': s.agent_id, 'tenant_uuid': s.tenant_uuid}
         self.queue = {'id': s.queue_id}
         self.tenants = ['fake-tenant']
 
@@ -185,7 +185,7 @@ class TestServiceProxy(unittest.TestCase):
         self.proxy.on_agent_deleted(self.agent)
 
         self.on_agent_handler.handle_on_agent_deleted.assert_called_once_with(
-            self.agent['id']
+            self.agent['id'], self.agent['tenant_uuid']
         )
 
     def test_on_agent_paused(self):


### PR DESCRIPTION
- **on_agent_deleted: clean up queue memberships on agent deletion**
- **logoff: use tenant_uuid from status instead of agent lookup**
- **on_queue_agent_paused: ignore pause events for deleted agents**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent login/logoff and event-driven cleanup paths; behavior changes on delete and on late pause events, mitigated by unit and integration tests.
> 
> **Overview**
> Fixes incomplete cleanup when a **logged agent is deleted** (e.g. unreachable phone), which could block another agent from logging in on the same extension.
> 
> **Agent deletion handling** now threads `tenant_uuid` from the `agent_deleted` bus event through the service proxy and `OnAgentDeletedManager`. For agents still logged in, the status is updated with that tenant before logoff, since the agent row is already gone. **Queue membership rows are always removed** via `remove_agent_from_all_queues`, including when there was no active login status.
> 
> **Logoff** no longer looks up the agent for `tenant_uuid`; it uses the value on `agent_status`, and `agent_dao` is dropped from `LogoffAction`.
> 
> **Queue member pause/unpause** events that arrive after deletion (e.g. Asterisk unpause on delete) no longer fail on a missing agent: tenant lookup `LookupError` is caught and bus publish is skipped.
> 
> Integration coverage adds a non-regression scenario (failed `QueueRemove`, then login another agent on the same extension) plus bus/AMI test helpers for `tenant_uuid` and simulated remove errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742091009dbb631eb59d89c3925710f03a4a6223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->