### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.08
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 ## 26.05
 
 * Added admin endpoints for per-queue agent login/logoff

--- a/etc/wazo-agentd/config.yml
+++ b/etc/wazo-agentd/config.yml
@@ -55,10 +55,16 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-  # Maximum of concurrent threads processing requests
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100
 
 service_discovery:
   enabled: false

--- a/wazo_agentd/config.py
+++ b/wazo_agentd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -38,7 +38,8 @@ _DEFAULT_CONFIG = {
             'enabled': True,
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'consul': {
         'scheme': 'http',

--- a/wazo_agentd/http.py
+++ b/wazo_agentd/http.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -136,10 +136,11 @@ class HTTPInterface:
         bind_addr = (self._config['listen'], self._config['port'])
 
         wsgi_app = ReverseProxied(ProxyFix(self._app))
-        self.server = wsgi.WSGIServer(
+        self.server = wsgi.DynamicWSGIServer(
             bind_addr,
             wsgi_app,
-            numthreads=self._config['max_threads'],
+            numthreads=self._config['min_threads'],
+            max=self._config['max_threads'],
         )
         if self._config['certificate'] and self._config['private_key']:
             logger.warning(


### PR DESCRIPTION

Depends-on: https://github.com/wazo-platform/xivo-dao/pull/350
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default concurrency and connection scaling (including raising default `max_threads` from 10 to 100), which can alter resource use and behavior under load on upgrade without explicit config overrides.
> 
> **Overview**
> Switches wazo-agentd’s REST server from a **fixed** `max_threads` pool at startup to **`DynamicWSGIServer`**, which keeps **`rest_api.min_threads`** workers ready and scales up to **`max_threads`** under load.
> 
> Defaults and docs now treat **`min_threads: 10`** as the always-on baseline (threads and DB connections) and **`max_threads: 100`** as the upper bound, replacing the previous model where `max_threads` alone fixed the pool size (formerly 10). Sample `etc/wazo-agentd/config.yml` and `_DEFAULT_CONFIG` in `config.py` are updated accordingly; **26.08** is noted in the changelog.
> 
> **Depends on** xivo-lib-python (`DynamicWSGIServer`) and related xivo-dao work from linked PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c9a391fc91326e359290bbcf83f03d1a9428e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->