### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 26.08
 
 * New `rest_api.min_threads` option: threads kept ready at all times.

--- a/etc/wazo-agentd/config.yml
+++ b/etc/wazo-agentd/config.yml
@@ -25,8 +25,7 @@ amid:
 
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
 
 # Bus connection to the AMQP server

--- a/integration_tests/assets/etc/wazo-agentd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-agentd/conf.d/50-default.yml
@@ -6,6 +6,8 @@ amid:
   host: amid
 auth:
   host: auth
+  port: 9497
+  prefix: null
   username: agentd-service
   password: agentd-password
 bus:

--- a/wazo_agentd/config.py
+++ b/wazo_agentd/config.py
@@ -16,8 +16,7 @@ _DEFAULT_CONFIG = {
     'amid': {'host': 'localhost', 'port': 9491, 'prefix': None, 'https': False},
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-agentd-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong deploy order (this before wazo-nginx/wazo-auth) breaks all internal auth and returns 404; production behavior otherwise is a config default change only.
> 
> **Overview**
> **Internal wazo-auth calls now target nginx** (`localhost:80`) instead of the wazo-auth daemon port (`9497`). Python defaults in `wazo_agentd/config.py` and the shipped `etc/wazo-agentd/config.yml` are updated together so runtime config stays consistent.
> 
> The explicit `auth.prefix: null` default is **removed** from those defaults; the auth client already uses `/api/auth` when prefix is unset.
> 
> **Integration test config** (`50-default.yml`) now **pins** `port: 9497` and `prefix: null` because test stacks talk to wazo-auth directly with no nginx.
> 
> Changelog **26.09** documents the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce98270d8211b08b9afc056b5fbca9390151821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->